### PR TITLE
Updated installation script for removing the comma in values of rawtobunbarcode table

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ If you have already iSkyLIMS on version 2.3.0 you can upgrade to the latest stab
 
 Version 3.0.0 is a major release with important upgrades in third parties dependencies like bootstrap. Also, we 've done a huge work on refactoring and variables/function renaming that affects the database. For more details about the changes see the release notes.
 
+If you requires to upgrade from version 3.0.0 to the latest one 3.1.x and in your system you have already defined library pools, then you need to collect this data, before to run the upgrade script. For more information read [Pre-requisites for upgrade from 3.0.0 to 3.1.x](#pre-requisites-for-upgrade-from-30x-to-31x)
+
 #### Pre-requisites
 
 Because in this upgrade many tables in database are modified it is required that you backup:

--- a/install.sh
+++ b/install.sh
@@ -563,7 +563,7 @@ if [ $upgrade == true ]; then
         else
             # execute the script to remove the comma in RawTopUnknowBarcodes table
             echo "Running migration script: remove_comma_rawtopunknownbarcodes"
-            ./manage.py runscript remove_comma_rawtopunknownbarcodes
+            ./manage.py runscript convert_rawtop_counter_to_int
             echo "checking for database changes"
             if python manage.py makemigrations | grep -q "No changes"; then
                 # check for pending migrations

--- a/install.sh
+++ b/install.sh
@@ -561,6 +561,9 @@ if [ $upgrade == true ]; then
             echo "Done migrate command."
 
         else
+            # execute the script to remove the comma in RawTopUnknowBarcodes table
+            echo "Running migration script: remove_comma_rawtopunknownbarcodes"
+            ./manage.py runscript remove_comma_rawtopunknownbarcodes
             echo "checking for database changes"
             if python manage.py makemigrations | grep -q "No changes"; then
                 # check for pending migrations

--- a/wetlab/scripts/convert_rawtop_counter_to_int.py
+++ b/wetlab/scripts/convert_rawtop_counter_to_int.py
@@ -8,9 +8,10 @@ def run():
     """
     top_bar_objs = wetlab.models.RawTopUnknowBarcodes.objects.all()
     for top_bar_obj in top_bar_objs:
-        try:
-            top_bar_obj.count = int(top_bar_obj.count.replace(",", ""))
-            top_bar_obj.save()
-        except AttributeError:
-            continue
+        if "," in top_bar_obj.count:
+            try:
+                top_bar_obj.count = int(top_bar_obj.count.replace(",", ""))
+                top_bar_obj.save()
+            except AttributeError:
+                continue
     return


### PR DESCRIPTION
Before to execute the migrations the "convert_rawtop_counter_to_int" script is executed to remove the commas in the value of RawTopUnknowBarcodes. 