### PR TITLE
Added in wetlab API to get run info from sample 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ documents/
 manage.py
 logs/
 logs
+.vscode/
 
 
 # Byte-compiled / optimized / DLL files

--- a/wetlab/api/urls.py
+++ b/wetlab/api/urls.py
@@ -5,7 +5,6 @@ app_name = "wetlab_api"
 
 
 urlpatterns = [
-    path("run-info", views.fetch_run_information, name="fetch_run_information"),
     path(
         "lab-data",
         views.get_lab_information_contact,

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -268,44 +268,35 @@ def create_sample_data(request):
 
 @swagger_auto_schema(
     method="get",
-    operation_description="Get the stored Run information available in iSkyLIMS for the list of samples",
-    manual_parameters=[sample_in_run],
-)
-@api_view(["GET"])
-def fetch_run_information(request):
-    if "samples" in request.GET:
-        samples = request.GET["samples"]
-        # sample_run_info = get_run_info_for_sample(apps_name, samples)
-        s_list = samples.strip().split(",")
-        s_data = []
-        for sample in s_list:
-            sample = sample.strip()
-            if wetlab.models.SamplesInProject.objects.filter(
-                sample_name__iexact=sample
-            ).exists():
-                s_found_objs = wetlab.models.SamplesInProject.objects.filter(
-                    sample_name__iexact=sample
-                )
-                for s_found_obj in s_found_objs:
-                    s_data.append(
-                        wetlab.api.serializers.SampleRunInfoSerializers(
-                            s_found_obj, many=False
-                        ).data
-                    )
-            else:
-                s_data.append({"sample_name": sample, "Run data": "Not found"})
-        return Response(s_data, status=status.HTTP_200_OK)
-    return Response(status=status.HTTP_400_BAD_REQUEST)
-
-
-@swagger_auto_schema(
-    method="get",
     operation_description="Get the sample/samples belongs to project information, collected when creating in iSkyLIMS",
     manual_parameters=[sample_information, sample_project_name, sample_parameter],
 )
 @api_view(["GET"])
 def fetch_sample_information(request):
+    """This request is used to get the sample information from the database. If
+    sequencing is received in the request, the request will return the run
+    information for this sample.
+    If not then all infromation is related to the sample creation, which means
+    sample project, project fields.
+    """
     sample_data = {}
+    if "sequencing" in request.GET and "sample" in request.GET:
+        sample = request.GET["sample"].strip()
+        s_data = []
+        if wetlab.models.SamplesInProject.objects.filter(
+            sample_name__iexact=sample
+        ).exists():
+            sample_obj = wetlab.models.SamplesInProject.objects.filter(
+                sample_name__iexact=sample
+            )
+            s_data.append(
+                wetlab.api.serializers.SampleRunInfoSerializers(
+                    sample_obj, many=False
+                ).data
+            )
+        else:
+            s_data.append({"sample_name": sample, "Run data": "Not found"})
+        return Response(s_data, status=status.HTTP_200_OK)
     if "sample" in request.GET:
         sample = request.GET["sample"]
         if not core.models.Samples.objects.filter(sample_name__iexact=sample).exists():

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -649,7 +649,7 @@ def fetch_remote_file(conn, run_dir, remote_file, local_file):
             string_message = (
                 "Unable to fetch the " + local_file + " file on folder : " + run_dir
             )
-            wetlab.utils.common.logging_warnings(string_message, True, False)
+            wetlab.utils.common.logging_warnings(string_message, False)
             os.remove(local_file)
             logger.debug(
                 "%s : End function for fetching remote file with Exception", run_dir

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -119,17 +119,18 @@ def search_update_new_runs(request_reason):
                 )
                 wetlab.utils.common.logging_warnings(error_message, True)
                 experiment_name = "Experiment name NOT FOUND"
-                wetlab.utils.common.logging_warnings(error_message, True)
                 # check the run folder creation date to allow more time before
                 # setting the run to error
-                f_created_date = wetlab.utils.common.get_samba_atribute_data(
-                    conn,
-                    wetlab.utils.crontab_process.get_samba_shared_folder(),
-                    new_run,
-                    "create_time",
+                f_created_date = int(
+                    wetlab.utils.common.get_samba_atribute_data(
+                        conn,
+                        wetlab.utils.crontab_process.get_samba_shared_folder(),
+                        new_run,
+                        "create_time",
+                    ).timestamp()
                 )
-                time_to_check = datetime.datetime.utcfromtimestamp(
-                    f_created_date
+                time_to_check = datetime.datetime.fromtimestamp(
+                    f_created_date, tz=datetime.timezone.utc
                 ).date()
                 max_time_for_run_parameters = (
                     wetlab.models.ConfigSetting.objects.filter(

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -117,9 +117,9 @@ def search_update_new_runs(request_reason):
                 error_message = (
                     "Unable to fetch RunParameter file for folder :" + new_run
                 )
-                wetlab.utils.common.logging_errors(error_message, True, False)
+                wetlab.utils.common.logging_warnings(error_message, True)
                 experiment_name = "Experiment name NOT FOUND"
-                wetlab.utils.common.logging_errors(error_message, True, False)
+                wetlab.utils.common.logging_warnings(error_message, True)
                 # check the run folder creation date to allow more time before
                 # setting the run to error
                 f_created_date = wetlab.utils.common.get_samba_atribute_data(
@@ -174,6 +174,9 @@ def search_update_new_runs(request_reason):
                             new_run + " : Experiment name field was not found in file"
                         )
                         wetlab.utils.common.logging_errors(string_message, False, False)
+                        wetlab.utils.crontab_process.handling_errors_in_run(
+                            new_run, "7"
+                        )
                     else:
                         string_message = (
                             new_run + " : Ignoring test folder " + experiment_name

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -325,7 +325,7 @@ def create_nextseq_run(request):
 
         # CHECK if file contains the extension.
         # Error page is showed if file does not contain any extension
-        split_filename = re.search("(.*)(\.\w+$)", myfile.name)
+        split_filename = re.search(r"(.*)(\.\w+$)", myfile.name)
         if split_filename is None:
             return render(
                 request,


### PR DESCRIPTION
Te following issue was implemented:

#109 Add parameter when requesting info from sample to decide if core or wetlab

Checking again the issue for "sending multiple emails " I found out a place that could also send 2 emails at the same time.