### PR TITLE
Fix issue #338: Removed unnecessary hidden input, now stored in session

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,15 @@
+name: Close Issues on Develop Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked issues
+        uses: peter-evans/close-issue@v2
+        with:
+          comment: "This issue is automatically closed as the fix has been merged into `develop`."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed deletion issue where removing a run also deleted pools and library preparations (#180) [#267](https://github.com/BU-ISCIII/iskylims/pull/267)
 - Fixed deprecated `STATUS_CHOICES` usage in Django versions higher than 3.1.x (#263) [#267](https://github.com/BU-ISCIII/iskylims/pull/267)
 - Fixed issue where services could not be searched by service type (#78) [#267](https://github.com/BU-ISCIII/iskylims/pull/267)
+- Fixed issue [#338](https://github.com/BU-ISCIII/iskylims/issues/338): Removed unnecessary hidden input passing a large JSON object, now using session storage [#344](https://github.com/BU-ISCIII/iskylims/pull/344)
 
 #### Changed
 

--- a/wetlab/templates/wetlab/record_project_fields.html
+++ b/wetlab/templates/wetlab/record_project_fields.html
@@ -65,7 +65,6 @@
 							id="project_data_form">
 							{% csrf_token %}
 							<input type="hidden" name="action" value="record_project_fields" />
-							<input type="hidden" name="projects_fields" value="{{ projects_fields|safe }}" />
 							{% for project in projects_fields %}
 							<h5 class="border-bottom d-inline-block">Project form: {{ project.sample_project_name }}
 							</h5>

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -2252,6 +2252,7 @@ def record_samples(request):
         try:
             # if we have projects, get the fields for each projects associated with the recorded samples
             projects_fields = core.utils.samples.project_table_fields(project_ids)
+            request.session["projects_fields"] = projects_fields
             # Render the project data form
             return render(
                 request,
@@ -2301,6 +2302,8 @@ def record_samples(request):
         try:
             # if we have projects, get the fields for each projects associated with the recorded samples
             projects_fields = core.utils.samples.project_table_fields(project_ids)
+            request.session["projects_fields"] = projects_fields
+
             # Render the project data form
             return render(
                 request,
@@ -2329,7 +2332,7 @@ def record_samples(request):
         projects_success = []
         json_data_all = []
 
-        projects_fields = eval(request.POST["projects_fields"])
+        projects_fields = request.session.get("projects_fields")
 
         for p_data in projects_fields:
             # Check if for any case there is no excel data sent for a project

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -2335,9 +2335,7 @@ def record_samples(request):
         projects_fields = request.session.get("projects_fields")
 
         if not projects_fields:
-            error_message = [
-                "Project fields not found."
-            ]
+            error_message = ["Project fields not found."]
             return render(
                 request,
                 "wetlab/record_project_fields.html",

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -2334,6 +2334,16 @@ def record_samples(request):
 
         projects_fields = request.session.get("projects_fields")
 
+        if not projects_fields:
+            error_message = [
+                "Project fields not found."
+            ]
+            return render(
+                request,
+                "wetlab/record_project_fields.html",
+                {"error_message": error_message},
+            )
+
         for p_data in projects_fields:
             # Check if for any case there is no excel data sent for a project
             if p_data["sample_project_name"] not in request.POST:


### PR DESCRIPTION
## Summary
Fix issue #338: Removed the unnecessary hidden input that was passing a huge JSON object. The data is now stored in the session, improving performance and security.

Added a new github action workflow to automattically close issues on merge to develop

## Changes
- Replaced hidden input storing `projects_fields` with session-based storage.
- Updated form submission handling to retrieve `projects_fields` from the session instead of `request.POST`.
- Added error handling in case session data is missing.

## Related Issues
Closes #338

## Checklist
Before submitting this PR, please ensure the following:

- [X] Code has been linted (`flake8`, `black`, or other linters used in the project).
- [X] Changes are documented in the `CHANGELOG.md`.
- [ ] Tests have been added or updated (if applicable).
- [X] The feature/fix has been tested locally.
- [X] The PR is targeted at the correct branch (`develop`, unless otherwise specified).

## Notes
- This update prevents large JSON truncation and improves request efficiency.
- Security is improved since the data is no longer exposed in the form.