### PR TITLE
Small fixes for docker installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased maximum length for `prefix_protocol` to prevent data errors. (#350) [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Corrected exception handling, replacing incorrect exception type with `AttributeError`. (#351) [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Fixed DataError - Value Too Long for prefix_protocol #350: Increased lenght for field prefix_protocol [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
+- Removed --no-cache from docker_install.sh as it only worked with deprecated docker-compose [#356](https://github.com/BU-ISCIII/iskylims/pull/356)
+- Removed unused field sample_project_searchable that was leading to errors during migration [#356](https://github.com/BU-ISCIII/iskylims/pull/356)
+- Fixed small spacing errors in docker-compose.yml [#356](https://github.com/BU-ISCIII/iskylims/pull/356)
 - Fixed KeyError in project schema loading by using default value for missing 'Downloadable' field.[#358](https://github.com/BU-ISCIII/iskylims/pull/358)
 - Wetlab api create_sample_data() also creates lab based on submitting_institution data if present [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
 - Wetlab api update_lab() now creates new lab if 'create_if_missing' in request.data [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
+
+
 
 #### Changed
 

--- a/conf/0002_core_migration_v3.0.0.py
+++ b/conf/0002_core_migration_v3.0.0.py
@@ -366,6 +366,11 @@ class Migration(migrations.Migration):
         ),
         migrations.RenameField(
             model_name="sampleprojectsfields",
+            old_name="sampleProjectSearchable",
+            new_name="sample_project_searchable",
+        ),
+        migrations.RenameField(
+            model_name="sampleprojectsfields",
             old_name="sampleProjects_id",
             new_name="sample_projects_id",
         ),

--- a/conf/0002_core_migration_v3.0.0.py
+++ b/conf/0002_core_migration_v3.0.0.py
@@ -366,11 +366,6 @@ class Migration(migrations.Migration):
         ),
         migrations.RenameField(
             model_name="sampleprojectsfields",
-            old_name="sampleProjectSearchable",
-            new_name="sample_project_searchable",
-        ),
-        migrations.RenameField(
-            model_name="sampleprojectsfields",
             old_name="sampleProjects_id",
             new_name="sample_projects_id",
         ),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
           start_period: 30s
         environment:
             MYSQL_DATABASE: iskylims_docker
-            MYSQL_USER : django
-            MYSQL_PASSWORD : djangopass
+            MYSQL_USER: django
+            MYSQL_PASSWORD: djangopass
             MYSQL_ROOT_PASSWORD: root
 
         ports:
@@ -46,7 +46,7 @@ services:
             - develop_net
         depends_on:
             db:
-              condition: service_healthy
+                condition: service_healthy
         volumes:
             - /etc/localtime:/etc/localtime:ro
             - /usr/share/zoneinfo:/usr/share/zoneinfo

--- a/docker_install.sh
+++ b/docker_install.sh
@@ -92,7 +92,7 @@ done
 shift $((OPTIND-1))
 
 echo "Deploying test containers with INSTALL_TYPE=$install_type and GIT_REVISION=$git_revision..."
-docker compose build --build-arg INSTALL_TYPE=$install_type --build-arg GIT_REVISION=$git_revision
+docker compose build --no-cache --build-arg INSTALL_TYPE=$install_type --build-arg GIT_REVISION=$git_revision
 docker compose up -d
 
 echo "Waiting 20 seconds for starting database and web services..."

--- a/docker_install.sh
+++ b/docker_install.sh
@@ -50,7 +50,7 @@ done
 
 # SETTING DEFAULT VALUES
 demo_data=false
-install_type="app"
+install_type="full"
 git_revision="main"
 
 # PARSE VARIABLE ARGUMENTS WITH getopts
@@ -92,7 +92,7 @@ done
 shift $((OPTIND-1))
 
 echo "Deploying test containers with INSTALL_TYPE=$install_type and GIT_REVISION=$git_revision..."
-docker compose build --no-cache --build-arg INSTALL_TYPE=$install_type --build-arg GIT_REVISION=$git_revision
+docker compose build --build-arg INSTALL_TYPE=$install_type --build-arg GIT_REVISION=$git_revision
 docker compose up -d
 
 echo "Waiting 20 seconds for starting database and web services..."

--- a/test/test_data.json
+++ b/test/test_data.json
@@ -252,7 +252,6 @@
             "sample_project_field_used": true,
             "sample_project_field_type": "String",
             "sample_project_option_list": "",
-            "sample_project_searchable": true,
             "generated_at": "2023-07-25T16:19:01.096"
         }
     },
@@ -268,7 +267,6 @@
             "sample_project_field_used": true,
             "sample_project_field_type": "String",
             "sample_project_option_list": "",
-            "sample_project_searchable": true,
             "generated_at": "2023-07-25T16:19:01.104"
         }
     },
@@ -284,7 +282,6 @@
             "sample_project_field_used": true,
             "sample_project_field_type": "String",
             "sample_project_option_list": "",
-            "sample_project_searchable": true,
             "generated_at": "2023-07-25T16:19:01.108"
         }
     },


### PR DESCRIPTION
- Removed `--no-cache` from docker_install.sh as it only worked with deprecated `docker-compose` but not with `docker compose`
- Removed unused field `sample_project_searchable` that was leading to errors during migration
- Fixed small spacing errors in `docker-compose.yml`