### PR TITLE
Updated Ontology Map and safe fallback for 'Downloadable' key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Luis Chapado](https://github.com/luissian)
 - [Daniel Valle](https://github.com/Daniel-VM)
 - [Pablo Mata](https://github.com/Shettland)
+- [Sergio Olmos]()
 
 #### Added Enhancements
 
@@ -55,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased max upload memory size. (#328)
 - Renamed method `get_delivery_date` to `get_delivered_date` for clarity.
 - Improved query performance and excluded rejected/archived services from ongoing list. (#299)
+- Updated sample metadata fields with standardized ontology mappings and schema alignment.[#358](https://github.com/BU-ISCIII/iskylims/pull/358)
 
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Luis Chapado](https://github.com/luissian)
 - [Daniel Valle](https://github.com/Daniel-VM)
 - [Pablo Mata](https://github.com/Shettland)
-- [Sergio Olmos]()
+- [Sergio Olmos](https://github.com/OPSergio)
 
 #### Added Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Increased maximum length for `prefix_protocol` to prevent data errors. (#350) [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Corrected exception handling, replacing incorrect exception type with `AttributeError`. (#351) [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Fixed DataError - Value Too Long for prefix_protocol #350: Increased lenght for field prefix_protocol [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
+- Fixed KeyError in project schema loading by using default value for missing 'Downloadable' field.[#358](https://github.com/BU-ISCIII/iskylims/pull/358)
 
 #### Changed
 

--- a/conf/ontology_maps.json
+++ b/conf/ontology_maps.json
@@ -20,7 +20,7 @@
     "pk": 3,
     "fields": {
         "label": "species",
-        "ontology": "GENEPIO:0001386"
+        "ontology": "SNOMED:410607006"
     }
 },
 {
@@ -28,7 +28,7 @@
     "pk": 4,
     "fields": {
         "label": "sample_name",
-        "ontology": "GENEPIO:0001123"
+        "ontology": "GENEPIO:0000079"
     }
 },
 {
@@ -36,7 +36,7 @@
     "pk": 6,
     "fields": {
         "label": "sampleEntryDate",
-        "ontology": "GENEPIO:0001179"
+        "ontology": "SNOMED:281271004"
     }
 },
 {
@@ -44,7 +44,7 @@
     "pk": 7,
     "fields": {
         "label": "collectionSampleDate",
-        "ontology": "GENEPIO:0001174"
+        "ontology": "SNOMED:399445004"
     }
 }
 ]

--- a/core/models.py
+++ b/core/models.py
@@ -949,7 +949,7 @@ class SampleProjectsFieldsManager(models.Manager):
             sample_project_field_order=project_field_data["Order"],
             sample_project_field_used=project_field_data["Used"],
             sample_project_field_type=project_field_data["Field type"],
-            sample_project_downloadable=project_field_data["Downloadable"],
+            sample_project_downloadable=project_field_data.get("Downloadable", False),
             # do not include optional values. Set to empty
             sample_project_option_list="",
         )


### PR DESCRIPTION
### Description

This PR updates sample metadata fields with standardized ontology mappings and schema alignment and fixed KeyError in project schema loading by using default value for missing 'Downloadable' field.

#### Changes made:

| Label                 | Ontology ID         | Mapped in Schema as             |
|-----------------------|---------------------|----------------------------------|
| `lab_request`         | `GENEPIO:0001153`   | `collecting_institution`        |
| `species`             | `SNOMED:410607006`  | `organism`                      |
| `sample_name`         | `GENEPIO:0000079`   | `sequencing_sample_id`          |
| `sample_entry_date`   | `SNOMED:281271004`  | `sample_received_date`          |
| `collection_sample_date` | `SNOMED:399445004` | `sample_collection_date`      |


- Updated the sample project field creation logic to safely access the `"Downloadable"` key using `project_field_data.get("Downloadable", False)`

