### PR TITLE
Wetlab API now also creates lab with submitting_institution data. New update mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Corrected exception handling, replacing incorrect exception type with `AttributeError`. (#351) [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Fixed DataError - Value Too Long for prefix_protocol #350: Increased lenght for field prefix_protocol [#352](https://github.com/BU-ISCIII/iskylims/pull/352)
 - Fixed KeyError in project schema loading by using default value for missing 'Downloadable' field.[#358](https://github.com/BU-ISCIII/iskylims/pull/358)
+- Wetlab api create_sample_data() also creates lab based on submitting_institution data if present [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
+- Wetlab api update_lab() now creates new lab if 'create_if_missing' in request.data [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
 
 #### Changed
 

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -526,12 +526,17 @@ def update_lab(request):
             if lab_obj is None:
                 if data.get("create_if_missing"):
                     wetlab.api.utils.sample.create_new_laboratory(data)
+                    return Response(
+                        "Successful Creation of new laboratory",
+                        status=status.HTTP_201_CREATED,
+                    )
                 else:
                     error_message = wetlab.config.ERROR_LABORATORY_NOT_FOUND
                     return Response(
                         error_message, status=status.HTTP_406_NOT_ACCEPTABLE
                     )
-            wetlab.api.serializers.LabRequestSerializer.update(lab_obj, data)
+            else:
+                wetlab.api.serializers.LabRequestSerializer.update(lab_obj, data)
 
             return Response(
                 "Successful Update information", status=status.HTTP_201_CREATED

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -233,6 +233,19 @@ def create_sample_data(request):
         inst_req_sample = wetlab.api.utils.sample.include_instances_in_sample(
             split_data["s_data"], split_data["lab_data"], apps_name
         )
+        required_submit_inst_fieldmap = {
+            "submitting_institution": "lab_name",
+            "submitting_institution_email": "lab_email",
+            "submitting_institution_address": "address",
+        }
+        if all(k in data for k in required_submit_inst_fieldmap.keys()):
+            submit_inst_data = split_data["lab_data"].copy()
+            for field, keymap in required_submit_inst_fieldmap.items():
+                submit_inst_data[keymap] = data[field]
+            submit_inst_data["lab_name_coding"] = "".join(
+                [x[0] for x in data["lab_name"].strip().split(" ")]
+            )
+            wetlab.api.utils.sample.create_new_laboratory(submit_inst_data)
         if not isinstance(inst_req_sample, dict):
             return Response(inst_req_sample, status=status.HTTP_400_BAD_REQUEST)
         split_data["s_data"] = inst_req_sample

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -524,8 +524,13 @@ def update_lab(request):
         if "lab_name" in data:
             lab_obj = wetlab.api.utils.lab.get_laboratory_instance(data["lab_name"])
             if lab_obj is None:
-                error_message = wetlab.config.ERROR_LABORATORY_NOT_FOUND
-                return Response(error_message, status=status.HTTP_406_NOT_ACCEPTABLE)
+                if data.get("create_if_missing"):
+                    wetlab.api.utils.sample.create_new_laboratory(data)
+                else:
+                    error_message = wetlab.config.ERROR_LABORATORY_NOT_FOUND
+                    return Response(
+                        error_message, status=status.HTTP_406_NOT_ACCEPTABLE
+                    )
             wetlab.api.serializers.LabRequestSerializer.update(lab_obj, data)
 
             return Response(


### PR DESCRIPTION
With these changes Wetlab API now also creates lab with submitting_institution data if the required fields are present in the request, this combination will automatically create laboratories for both collecting and submitting institutions.

On the other hand, I included an exceptional method in `wetlab.api.views.update_lab()` to create the laboratory from the request if `'create_if_missing'` is present in the input data.