### PR TITLE
LabRequest serializer update method fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow switching to Git SHA or Version Tag and restore initial state [#270](https://github.com/BU-ISCIII/iskylims/pull/270)
 - Created graphics for the services that were re-analyzed [#290](https://github.com/BU-ISCIII/iskylims/pull/290)
 - Enhance both `install.sh` and `docker_install.sh`, fix data loading issues [#327](https://github.com/BU-ISCIII/iskylims/pull/327)
+- Included thorough description for wetlab API's update_lab() method [#361](https://github.com/BU-ISCIII/iskylims/pull/361)
 
 #### Fixes
 
@@ -49,6 +50,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed KeyError in project schema loading by using default value for missing 'Downloadable' field.[#358](https://github.com/BU-ISCIII/iskylims/pull/358)
 - Wetlab api create_sample_data() also creates lab based on submitting_institution data if present [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
 - Wetlab api update_lab() now creates new lab if 'create_if_missing' in request.data [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
+- Fixed wetlab API's labrequest.serializer update method to work properly [#361](https://github.com/BU-ISCIII/iskylims/pull/361)
+- Adapted update_lab serializer call to new serializer update method [#361](https://github.com/BU-ISCIII/iskylims/pull/361)
 
 #### Changed
 

--- a/wetlab/api/serializers.py
+++ b/wetlab/api/serializers.py
@@ -241,12 +241,12 @@ class LabRequestSerializer(serializers.ModelSerializer):
             "lab_city",
         ]
 
-    def update(self, data):
-        self.labContactName = data["lab_contact_name"]
-        self.labPhone = data["lab_contact_telephone"]
-        self.labEmail = data["lab_contact_email"]
-        self.save()
-        return self
+    def update(self, instance, validated_data):
+        instance.lab_contact_name = validated_data.get("lab_contact_name", instance.lab_contact_name)
+        instance.lab_phone = validated_data.get("lab_phone", instance.lab_phone)
+        instance.lab_email = validated_data.get("lab_email", instance.lab_email)
+        instance.save()
+        return instance
 
 
 class SampleFields(object):

--- a/wetlab/api/serializers.py
+++ b/wetlab/api/serializers.py
@@ -242,7 +242,9 @@ class LabRequestSerializer(serializers.ModelSerializer):
         ]
 
     def update(self, instance, validated_data):
-        instance.lab_contact_name = validated_data.get("lab_contact_name", instance.lab_contact_name)
+        instance.lab_contact_name = validated_data.get(
+            "lab_contact_name", instance.lab_contact_name
+        )
         instance.lab_phone = validated_data.get("lab_phone", instance.lab_phone)
         instance.lab_email = validated_data.get("lab_email", instance.lab_email)
         instance.save()

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -517,6 +517,35 @@ def statistic_information(request):
 @api_view(["PUT"])
 @permission_classes([IsAuthenticated])
 def update_lab(request):
+    """
+    Handles updating or creating a laboratory instance based on incoming PUT request data.
+
+    If a lab with the provided `lab_name` exists, it updates the existing record.
+    If the lab does not exist and the `create_if_missing` flag is set in request.data,
+    it attempts to create a new lab using the provided information.
+
+    Required key in request.data:
+        - lab_name (str): The name of the laboratory to update or create.
+
+    Optional required keys (if lab does not exist and `create_if_missing` is True):
+        - lab_contact_name (str) <- updates data if lab exists
+        - lab_phone (str) <- updates data if lab exists
+        - lab_email (str) <- updates data if lab exists
+        - apps_name (str)
+        - geo_loc_city (str)
+        - geo_loc_state (str)
+        - lab_name_coding (str)
+        - lab_unit (str)
+
+    Args:
+        request (HttpRequest): The incoming HTTP request containing PUT data.
+
+    Returns:
+        Response:
+            - 201 Created: If the lab is successfully created or updated.
+            - 406 Not Acceptable: If the lab is not found or cannot be created, or if the data is invalid.
+            - 400 Bad Request: If the HTTP method is not PUT.
+    """
     if request.method == "PUT":
         data = request.data
         if isinstance(data, QueryDict):
@@ -536,9 +565,21 @@ def update_lab(request):
                         error_message, status=status.HTTP_406_NOT_ACCEPTABLE
                     )
             else:
-                wetlab.api.serializers.LabRequestSerializer.update(lab_obj, data)
-
+                serializer = wetlab.api.serializers.LabRequestSerializer(
+                    lab_obj, data=data, partial=True
+                )
+                if serializer.is_valid():
+                    serializer.save()
+                    return Response(
+                        "Successful Update information", status=status.HTTP_201_CREATED
+                    )
+                else:
+                    return Response(
+                        serializer.errors, status=status.HTTP_406_NOT_ACCEPTABLE
+                    )
+        else:
             return Response(
-                "Successful Update information", status=status.HTTP_201_CREATED
+                "Missing 'lab_name' field in request data",
+                status=status.HTTP_406_NOT_ACCEPTABLE,
             )
     return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Implemented a correction to update fix as it was not admitting the lab_object as input, resulting in no effective update. 

On the other hand I adapted update_lab method from wetlab api to this change, and added a thorough description in order to understand how it works.