### PR TITLE
Leave missing submitting_fields as empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Wetlab api update_lab() now creates new lab if 'create_if_missing' in request.data [#360](https://github.com/BU-ISCIII/iskylims/pull/360)
 - Fixed wetlab API's labrequest.serializer update method to work properly [#361](https://github.com/BU-ISCIII/iskylims/pull/361)
 - Adapted update_lab serializer call to new serializer update method [#361](https://github.com/BU-ISCIII/iskylims/pull/361)
+- Leave missing submitting_fields as empty string instead of crashing in wetlab.api.create_sample_data [#363](https://github.com/BU-ISCIII/iskylims/pull/363)
 
 #### Changed
 

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -241,7 +241,7 @@ def create_sample_data(request):
         if all(k in data for k in required_submit_inst_fieldmap.keys()):
             submit_inst_data = split_data["lab_data"].copy()
             for field, keymap in required_submit_inst_fieldmap.items():
-                submit_inst_data[keymap] = data[field]
+                submit_inst_data[keymap] = data.get(field, "")
             submit_inst_data["lab_name_coding"] = "".join(
                 [x[0] for x in data["lab_name"].strip().split(" ")]
             )


### PR DESCRIPTION
This PR addresses a possible wetlab's API error during sample upload from relecov project when submitting_institution fields are missing Instead of crashing, these fields will be included as empty strings `""` so they can be updated later via API's `update_lab()`