### PR TITLE
Add support for SamplesheetV2 and MiSeq sequencer

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1791,7 +1791,7 @@ class SequencerInLabManager(models.Manager):
             platform_obj = SequencingPlatform.objects.get(
                 pk__exact=sequencer_value["platformID"]
             )
-        except models.SequencingPlatform.DoesNotExist:
+        except SequencingPlatform.DoesNotExist:
             platform_obj = None
         new_sequencer = self.create(
             platform_id=platform_obj,

--- a/core/scripts/migrate_sample_type.py
+++ b/core/scripts/migrate_sample_type.py
@@ -1,6 +1,5 @@
 import core.models
 
-
 """
     The script is applicable for the upgrade from 2.3.0 to 3.0.0.
     Because the new version changes the value that is stored now is the field

--- a/core/scripts/rename_app_name.py
+++ b/core/scripts/rename_app_name.py
@@ -1,6 +1,5 @@
 import core.models
 
-
 """
     The script is applicable for the upgrade from 2.3.0 to 3.0.0.
     Because the application in iSkylims have been renamed, this required that

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -1878,7 +1878,7 @@ def record_extract_protocol(samples, excel_data, heading, user, app_name):
             return_data.append(r_data)
         # collect data for dropdown selection
         protocol_filter_selection = []
-        (protocols_dict, protocol_list) = get_molecule_protocols(app_name)
+        protocols_dict, protocol_list = get_molecule_protocols(app_name)
         for key, value in protocols_dict.items():
             protocol_filter_selection.append([key, value])
         return {

--- a/django_utils/templatetags/user_text.py
+++ b/django_utils/templatetags/user_text.py
@@ -1,6 +1,5 @@
 from django import template
 
-
 register = template.Library()
 
 

--- a/drylab/scripts/drylab_service_state_migration.py
+++ b/drylab/scripts/drylab_service_state_migration.py
@@ -1,6 +1,5 @@
 from drylab.models import Service, ServiceState
 
-
 """
     The script is applicable for the upgrade from 2.3.0 to 2.3.1.
     Service state that was defined as option choice in  models,is replaced in

--- a/drylab/templatetags/upload_tags.py
+++ b/drylab/templatetags/upload_tags.py
@@ -6,8 +6,7 @@ register = template.Library()
 
 @register.simple_tag
 def upload_js():
-    return mark_safe(
-        """
+    return mark_safe("""
             <!-- The template to display files available for upload -->
             <script id="template-upload" type="text/x-tmpl">
             {% for (var i=0, file; file=o.files[i]; i++) { %}
@@ -96,5 +95,4 @@ def upload_js():
                 </tr>
             {% } %}
             </script>
-            """
-    )
+            """)

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -337,6 +337,18 @@ MAP_USER_SAMPLE_SHEET_ADDITIONAL_FIELDS_FROM_TYPE_OF_SECUENCER = [
 # Sections to check in the IEM file created by user
 SECTIONS_IN_IEM_SAMPLE_SHEET = ["[Header]", "[Reads]", "[Settings]", "[Data]"]
 
+# Tabular data sections in samplesheets. For future references: Insert in order.
+TABULAR_DATA_SECTIONS_SAMPLE_SHEET = [
+    "Data", 
+    "CustomCustomer_Data", 
+    "BCLConvert_Data"
+]
+
+SETTINGS_SECTIONS_SAMPLE_SHEET = [
+    "Settings",
+    "BCLConvert_Settings"
+]
+
 FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5 = [
     "Date",
     "Experiment Name",
@@ -348,6 +360,17 @@ FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5 = [
     "Chemistry",
     "Description",
 ]
+
+ADAPTER_1_FIELD_NAMES = [
+    "Adapter",
+    "AdapterRead1"
+]
+
+ADAPTER_2_FIELD_NAMES = [
+    "Adapter",
+    "AdapterRead2"
+]
+
 
 # #### HEADINGS VALUES
 
@@ -685,6 +708,9 @@ ERROR_SAMPLE_SHEET_WHEN_FETCHING_USERID_NAMES = [
 ]
 ERROR_SAMPLE_SHEET_USER_ARE_NOT_DEFINED = (
     "Sample sheet has users which are not defined : "
+)
+ERROR_SAMPLE_SHEET_HAS_INVALID_LINES = (
+    "Sample sheet has an invalid (Non-empty, non-comma-delimited) line: "
 )
 ERROR_USER_SAMPLE_SHEET_NO_LONGER_EXISTS = [
     "The Sample Sheet that you are uploaded does not longer exists",

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -77,8 +77,8 @@ PLATFORM_WAY_TO_CHECK_RUN_COMPLETION = [
 ]
 
 # ########### VALUE TAG FOR XML FILES #########################
-COMPLETION_TAG = "CompletionStatus"
-COMPLETION_SUCCESS = ["CompletedAsPlanned", "SuccessfullyCompleted"]
+COMPLETION_TAG = ["CompletionStatus", "RunStatus"]
+COMPLETION_SUCCESS = ["CompletedAsPlanned", "SuccessfullyCompleted", "RunCompleted"]
 EXPERIMENT_NAME_TAG = "ExperimentName"
 APPLICATION_NAME_TAG = "ApplicationName"
 NUMBER_CYCLES_TAG = "NumCycles"

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -348,16 +348,10 @@ SECTIONS_IN_V2_SAMPLE_SHEET = [
 
 # Possible names of the Tabular data iskylims user field
 
-TABULAR_DATA_ISKYLIMS_USER_COLUMN = {
-    "1": "Description", 
-    "2": "custom_description"
-}
+TABULAR_DATA_ISKYLIMS_USER_COLUMN = {"1": "Description", "2": "custom_description"}
 
 # Tabular data sections in samplesheets.
-TABULAR_DATA_SECTIONS_SAMPLE_SHEET = {
-    "1": "Data",
-    "2": "BCLConvert_Data"
-}
+TABULAR_DATA_SECTIONS_SAMPLE_SHEET = {"1": "Data", "2": "BCLConvert_Data"}
 
 SETTINGS_SECTIONS_SAMPLE_SHEET = ["Settings", "BCLConvert_Settings"]
 

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -226,15 +226,10 @@ HEADING_FOR_SAMPLE_SHEET_ONE_INDEX = [
 HEADING_FOR_SAMPLE_SHEET_TWO_INDEX = [
     "Unique_Sample_ID",
     "Sample_Name",
-    "Sample_Plate",
-    "Sample_Well",
-    "Index_Plate_Well",
-    "I7_Index_ID",
     "index",
-    "I5_Index_ID",
     "index2",
     "Sample_Project",
-    "Description",
+    "custom_description",
 ]
 
 
@@ -248,6 +243,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_NEXTSEQ_SINGLE_READ = [
     ("index", "i7Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 MAP_USER_SAMPLE_SHEET_TO_DATABASE_NEXTSEQ_PAIRED_END = [
@@ -261,6 +257,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_NEXTSEQ_PAIRED_END = [
     ("index2", "i5Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_SINGLE_READ_VERSION_5 = [
@@ -272,6 +269,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_SINGLE_READ_VERSION_5 = [
     ("index", "i7Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_PAiRED_END_VERSION_5 = [
@@ -285,6 +283,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_PAiRED_END_VERSION_5 = [
     ("index2", "i5Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_SINGLE_READ_VERSION_4 = [
@@ -296,6 +295,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_SINGLE_READ_VERSION_4 = [
     ("index", "i7Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_PAiRED_END_VERSION_4 = [
@@ -309,6 +309,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_MISEQ_PAiRED_END_VERSION_4 = [
     ("index2", "i5Index"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 
 
@@ -326,6 +327,7 @@ MAP_USER_SAMPLE_SHEET_TO_DATABASE_ALL_PLATFORMS = [
     ("GenomeFolder", "genomeFolder"),
     ("Sample_Project", "projectInSampleSheet"),
     ("Description", "userInSampleSheet"),
+    ("custom_description", "userInSampleSheet"),
 ]
 # ######## MAPPING OPTIONAL COLUMNS THAT COULD BE IN SAMPLE SHEET FROM USER TO DATABASE   #############
 MAP_USER_SAMPLE_SHEET_ADDITIONAL_FIELDS_FROM_TYPE_OF_SECUENCER = [
@@ -344,8 +346,18 @@ SECTIONS_IN_V2_SAMPLE_SHEET = [
     "CustomCustomer_Data",
 ]
 
-# Tabular data sections in samplesheets. For future references: Insert in order.
-TABULAR_DATA_SECTIONS_SAMPLE_SHEET = ["Data", "CustomCustomer_Data", "BCLConvert_Data"]
+# Possible names of the Tabular data iskylims user field
+
+TABULAR_DATA_ISKYLIMS_USER_COLUMN = {
+    "1": "Description", 
+    "2": "custom_description"
+}
+
+# Tabular data sections in samplesheets.
+TABULAR_DATA_SECTIONS_SAMPLE_SHEET = {
+    "1": "Data",
+    "2": "BCLConvert_Data"
+}
 
 SETTINGS_SECTIONS_SAMPLE_SHEET = ["Settings", "BCLConvert_Settings"]
 

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -335,7 +335,8 @@ MAP_USER_SAMPLE_SHEET_ADDITIONAL_FIELDS_FROM_TYPE_OF_SECUENCER = [
 ]
 
 # Sections to check in the IEM file created by user
-SECTIONS_IN_IEM_SAMPLE_SHEET = ["[Header]", "[Reads]", "[Settings]", "[Data]"]
+SECTIONS_IN_IEM_SAMPLE_SHEET = ["Header", "Reads", "Settings", "Data"]
+SECTIONS_IN_V2_SAMPLE_SHEET = ["Header", "Reads", "BCLConvert_Settings", "BCLConvert_Data", "CustomCustomer_Data"]
 
 # Tabular data sections in samplesheets. For future references: Insert in order.
 TABULAR_DATA_SECTIONS_SAMPLE_SHEET = [

--- a/wetlab/config.py
+++ b/wetlab/config.py
@@ -336,19 +336,18 @@ MAP_USER_SAMPLE_SHEET_ADDITIONAL_FIELDS_FROM_TYPE_OF_SECUENCER = [
 
 # Sections to check in the IEM file created by user
 SECTIONS_IN_IEM_SAMPLE_SHEET = ["Header", "Reads", "Settings", "Data"]
-SECTIONS_IN_V2_SAMPLE_SHEET = ["Header", "Reads", "BCLConvert_Settings", "BCLConvert_Data", "CustomCustomer_Data"]
+SECTIONS_IN_V2_SAMPLE_SHEET = [
+    "Header",
+    "Reads",
+    "BCLConvert_Settings",
+    "BCLConvert_Data",
+    "CustomCustomer_Data",
+]
 
 # Tabular data sections in samplesheets. For future references: Insert in order.
-TABULAR_DATA_SECTIONS_SAMPLE_SHEET = [
-    "Data", 
-    "CustomCustomer_Data", 
-    "BCLConvert_Data"
-]
+TABULAR_DATA_SECTIONS_SAMPLE_SHEET = ["Data", "CustomCustomer_Data", "BCLConvert_Data"]
 
-SETTINGS_SECTIONS_SAMPLE_SHEET = [
-    "Settings",
-    "BCLConvert_Settings"
-]
+SETTINGS_SECTIONS_SAMPLE_SHEET = ["Settings", "BCLConvert_Settings"]
 
 FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5 = [
     "Date",
@@ -362,15 +361,9 @@ FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5 = [
     "Description",
 ]
 
-ADAPTER_1_FIELD_NAMES = [
-    "Adapter",
-    "AdapterRead1"
-]
+ADAPTER_1_FIELD_NAMES = ["Adapter", "AdapterRead1"]
 
-ADAPTER_2_FIELD_NAMES = [
-    "Adapter",
-    "AdapterRead2"
-]
+ADAPTER_2_FIELD_NAMES = ["Adapter", "AdapterRead2"]
 
 
 # #### HEADINGS VALUES

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -299,9 +299,12 @@ def check_sequencer_status_from_completion_file(l_run_completion, experiment_nam
         experiment_name,
     )
     # check if NextSEq run have been successful completed
-    status_run = wetlab.utils.common.find_xml_tag_text(
-        l_run_completion, wetlab.config.COMPLETION_TAG
-    )
+    for xml_tag in wetlab.config.COMPLETION_TAG:
+        status_run = wetlab.utils.common.find_xml_tag_text(
+            l_run_completion, xml_tag
+        )
+        if status_run != "NOT FOUND":
+            break
     if status_run not in wetlab.config.COMPLETION_SUCCESS:
         logger.info(
             "%s : Run in sequencer was not completed but %s",
@@ -445,7 +448,7 @@ def check_sequencer_run_is_completed(
             "%s : End function check_sequencer_run_is_completed with exception",
             experiment_name,
         )
-        return "cancelled", ""
+        return "cancelled", None
     elif way_to_check == "txt_file":
         # l_run_completion = os.path.join(RUN_TEMP_DIRECTORY, RUN_COMPLETION_TXT_FILE)
         s_run_completion = os.path.join(
@@ -1119,6 +1122,8 @@ def parsing_run_info_and_parameter_information(
                 wetlab.utils.common.logging_warnings(string_message, False)
     # get date for miSeq and NextSeq with the format yymmdd
     date = p_run.find("Date").text
+    # Remove timestamp
+    date = date.split("T")[0]
     try:
         run_date = datetime.datetime.strptime(date, "%y%m%d")
     except Exception:

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -300,9 +300,7 @@ def check_sequencer_status_from_completion_file(l_run_completion, experiment_nam
     )
     # check if NextSEq run have been successful completed
     for xml_tag in wetlab.config.COMPLETION_TAG:
-        status_run = wetlab.utils.common.find_xml_tag_text(
-            l_run_completion, xml_tag
-        )
+        status_run = wetlab.utils.common.find_xml_tag_text(l_run_completion, xml_tag)
         if status_run != "NOT FOUND":
             break
     if status_run not in wetlab.config.COMPLETION_SUCCESS:

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -584,9 +584,7 @@ def manage_run_in_recorded_state(conn, run_process_objs):
                 run_process_obj, l_sample_sheet_path, experiment_name
             )
 
-        if (
-            "NextSeq" in run_process_obj.get_run_platform()
-        ):
+        if "NextSeq" in run_process_obj.get_run_platform():
             sample_sheet_path = run_process_obj.get_sample_file()
 
             try:

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -330,7 +330,7 @@ def search_update_new_runs(request_reason):
                     == "TRUE"
                 ):
                     user_id_list = wetlab.utils.common.get_userid_list()
-                    file_read = wetlab.utils.samplesheet.read_user_iem_file(
+                    file_read = wetlab.utils.samplesheet.read_file_from_path(
                         l_sample_sheet_path
                     )
                     users = wetlab.utils.samplesheet.validate_userid_in_user_iem_file(

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -585,8 +585,8 @@ def manage_run_in_recorded_state(conn, run_process_objs):
             )
 
         if (
-            wetlab.config.COPY_SAMPLE_SHEET_TO_REMOTE
-            and "NextSeq" in run_process_obj.get_run_platform()
+            #wetlab.config.COPY_SAMPLE_SHEET_TO_REMOTE
+            "NextSeq" in run_process_obj.get_run_platform()
         ):
             sample_sheet_path = run_process_obj.get_sample_file()
 

--- a/wetlab/utils/crontab_update_run.py
+++ b/wetlab/utils/crontab_update_run.py
@@ -585,7 +585,6 @@ def manage_run_in_recorded_state(conn, run_process_objs):
             )
 
         if (
-            #wetlab.config.COPY_SAMPLE_SHEET_TO_REMOTE
             "NextSeq" in run_process_obj.get_run_platform()
         ):
             sample_sheet_path = run_process_obj.get_sample_file()

--- a/wetlab/utils/library.py
+++ b/wetlab/utils/library.py
@@ -859,19 +859,19 @@ def format_sample_sheet_to_display_in_form(sample_sheet_data):
         display_data["adapter2"] = True
 
     display_data["sample_data"] = sample_sheet_data["sample_data"]
-    display_data["heading"] = sample_sheet_data["heading"]
+    display_data["headers"] = sample_sheet_data["headers"]
     main_values = []
     for item in extract_values:
         main_values.append(sample_sheet_data[item])
     summary_values = []
     summary_values.append(len(sample_sheet_data["samples"]))
-    summary_values.append(sample_sheet_data["proyects"])
+    summary_values.append(sample_sheet_data["projects"])
     summary_values.append(sample_sheet_data["userid_names"])
     display_data["main_data"] = list(zip(main_data_heading, main_values))
     display_data["summary_data"] = list(
         zip(wetlab.config.HEADING_SUMMARY_DATA_SAMPLE_SHEET, summary_values)
     )
-    display_data["heading_excel"] = ",".join(sample_sheet_data["heading"])
+    display_data["headers_excel"] = ",".join(sample_sheet_data["headers"])
     # if len(sample_sheet_data['userid_names']) == 0:
     #    display_data['no_user_defined'] = True
 

--- a/wetlab/utils/run.py
+++ b/wetlab/utils/run.py
@@ -37,12 +37,8 @@ def check_run_already_defined_by_crontab(exp_name, pool_ids):
     sample_sheet_path = run_obj.get_sample_file()
     f_name = os.path.join(settings.MEDIA_ROOT, sample_sheet_path)
     try:
-        file_data = wetlab.utils.samplesheet.read_file_from_path(
-            f_name
-        )
-        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(
-            file_data
-        )
+        file_data = wetlab.utils.samplesheet.read_file_from_path(f_name)
+        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(file_data)
     except FileNotFoundError:
         error_message = str(
             wetlab.config.ERROR_RUN_NAME_BY_CRONTAB_ALREADY_CREATED
@@ -50,7 +46,9 @@ def check_run_already_defined_by_crontab(exp_name, pool_ids):
             + wetlab.config.ERROR_SAMPLE_SHEET_NOT_FOUND_WHEN_CREATED_BY_CRONTAB
         )
         return {"ERROR": error_message}
-    sample_in_s_sheet = wetlab.utils.samplesheet.get_samples_in_sample_sheet(samplesheet)
+    sample_in_s_sheet = wetlab.utils.samplesheet.get_samples_in_sample_sheet(
+        samplesheet
+    )
     sample_in_pools = wetlab.utils.pool.get_sample_name_in_pools(pool_ids)
     if len(sample_in_pools) != len(sample_in_s_sheet["samples"]):
         return {"ERROR": wetlab.config.ERROR_EXISTING_RUN_WITH_DIF_SAMPLES_AS_IN_CRON}

--- a/wetlab/utils/run.py
+++ b/wetlab/utils/run.py
@@ -34,11 +34,15 @@ def check_run_already_defined_by_crontab(exp_name, pool_ids):
     # experiment name already exists, check if samples are the same
     # to confirm the match
     run_obj = wetlab.models.RunProcess.objects.filter(run_name__iexact=exp_name).last()
-    sample_sheet = run_obj.get_sample_file()
-    f_name = os.path.join(settings.MEDIA_ROOT, sample_sheet)
+    sample_sheet_path = run_obj.get_sample_file()
+    f_name = os.path.join(settings.MEDIA_ROOT, sample_sheet_path)
     try:
-        with open(f_name, "r") as fh:
-            file_data = fh.readlines()
+        file_data = wetlab.utils.samplesheet.read_file_from_path(
+            f_name
+        )
+        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(
+            file_data
+        )
     except FileNotFoundError:
         error_message = str(
             wetlab.config.ERROR_RUN_NAME_BY_CRONTAB_ALREADY_CREATED
@@ -46,7 +50,7 @@ def check_run_already_defined_by_crontab(exp_name, pool_ids):
             + wetlab.config.ERROR_SAMPLE_SHEET_NOT_FOUND_WHEN_CREATED_BY_CRONTAB
         )
         return {"ERROR": error_message}
-    sample_in_s_sheet = wetlab.utils.samplesheet.get_samples_in_sample_sheet(file_data)
+    sample_in_s_sheet = wetlab.utils.samplesheet.get_samples_in_sample_sheet(samplesheet)
     sample_in_pools = wetlab.utils.pool.get_sample_name_in_pools(pool_ids)
     if len(sample_in_pools) != len(sample_in_s_sheet["samples"]):
         return {"ERROR": wetlab.config.ERROR_EXISTING_RUN_WITH_DIF_SAMPLES_AS_IN_CRON}

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -405,6 +405,7 @@ def get_index_library_name(in_file):
 
 
 def update_library_kit_field(library_file_name, library_kit_name, library_name):
+    # FIXME This function is not used anywhere - Not going to touch it for now
     # result_directory='documents/wetlab/BaseSpaceMigrationFiles/'
     timestr = time.strftime("%Y%m%d-%H%M%S")
     tmp = re.search(r"(.*)\d{8}-\d+.*\.csv", library_file_name)

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -463,62 +463,54 @@ def update_sample_sheet(in_file, experiment_name):
     os.rename(temp, in_file)
 
 
-def create_unique_sample_id_values(infile, index_file):
-    found_sample_line = False
+def create_unique_sample_id_values(in_file: str, index_file: str):
+    """
+    Create unique sample IDs for samples in the samplesheets by using an ongoing index.
 
-    fh = open(infile, "r")
-    temp_sample_sheet = os.path.join(settings.MEDIA_ROOT, "wetlab", "tmp_file")
-    fh_out_file = open(temp_sample_sheet, "w")
-    with open(index_file) as fh_index:
-        index = fh_index.readline()
-        index = index.rstrip()
-        index_number_str, index_letter = index.split("-")
-        fh_index.close()
+    Args:
+        in_file (str): Path to samplesheet
+        index_file (str): Path to index_file
+    """
+    file_read = read_file_from_path(in_file)
+    samplesheet = file_read_to_dictionary(file_read)
 
-    for line in fh:
-        if "Sample_ID" in line:
-            found_sample_line = True
-            fh_out_file.write(line)
-            continue
-        if found_sample_line:
-            # discard the empty lines or the lines that contains empty lines separated by comma
-            if line == "\n" or re.search(r"^\W", line):
-                continue
+    with open(index_file, "r") as f:
+        try:  # catch OSError in case of a one line file 
+            f.seek(-2, os.SEEK_END)
+            while f.read(1) != b'\n':
+                f.seek(-2, os.SEEK_CUR)
+        except OSError:
+            f.seek(0)
+        last_line = f.readline().decode()
+        index_number_str, index_letter = last_line.rstrip().split("-")
+        index_number = int(index_number_str)
+    data = get_tabular_data(samplesheet, header_includes="Sample_ID")
+    for row in data[1:]:
+        index_number += 1
+        index_number = index_number % (10000) # Return only 4 last digits, effectively restarting at 10000
+        if index_number == 0:
+            # When index re-starts, we move on to the next letter
+            index_letter_parts = list(index_letter)
+            # Reverse order to
+            for i in [1,0]:
+                ascii_index_letter = ord(index_letter_parts[i])
+                ascii_index_letter += 1
+                ascii_index_letter = ascii_index_letter if ascii_index_letter <= 90 else 65
+                index_letter_parts[i] = chr(ascii_index_letter)
+                if ascii_index_letter != 65:
+                    break
+            # Reverse and stringify the index letter parts
+            index_letter = "".join(index_letter_parts)
+        # Create unique sample ID and overwrite Sample_ID
+        sample_unique_id = f"{str(index_number).zfill(4)}-{index_letter}"
+        row[0] = sample_unique_id
+    
+    # Dump the index value to file
+    with open(index_file, "w") as f:
+        f.write(sample_unique_id)
 
-            data_line = line.split(",")
-            data_line[0] = str(index_number_str + "-" + index_letter)
-            new_line = ",".join(data_line)
-            fh_out_file.write(new_line)
-            # increase the index number
-            index_number = int(index_number_str) + 1
-            if index_number > 9999:
-                index_number = 0
-                # increase a letter
-                split_index_letter = list(index_letter)
-                if split_index_letter[1] == "Z":
-                    last_letter = chr(ord(split_index_letter[0]) + 1)
-                    split_index_letter[0] = last_letter
-                    split_index_letter[1] = "A"
-                    index_letter = "".join(split_index_letter)
-                else:
-                    first_letter = chr(ord(split_index_letter[1]) + 1)
-                    split_index_letter[1] = first_letter
-                    index_letter = "".join(split_index_letter)
-
-            index_number_str = str(index_number)
-            index_number_str = index_number_str.zfill(4)
-
-        else:
-            fh_out_file.write(line)
-
-    # dump the index value to file
-    fh_index = open(index_file, "w")
-    index_line = str(index_number_str + "-" + index_letter)
-    fh_index.write(index_line)
-    fh_index.close()
-    fh.close()
-    fh_out_file.close()
-    os.rename(temp_sample_sheet, infile)
+    # Dump the updated samplesheet
+    write_samplesheet_to_path(samplesheet, in_file)
 
 
 def set_user_names_in_sample_sheet(in_file, user_names):

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -14,6 +14,60 @@ import wetlab.config
 
 # import wetlab.models
 
+def read_file_from_path(file_path: str) -> str:
+    """
+    Read file from path, ensuring characters are not lost due to encoding
+    
+    :param file_path: Description
+    :type file_path: str
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            read_file = f.read()
+    except Exception:
+        return False
+    return read_file
+
+
+def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[list[str]]]:
+    """
+    Description:
+        This function transforms a SampleSheet from string to dictionary,
+        loading the headers as keys. If data is fully tabular (e.g. [Data]),
+        load rows as list of list; if not, nested dict.
+    Input:
+        file_read           # content of the IEM file from user
+    Constant:
+        ERROR_SAMPLE_SHEET_HAS_INVALID_LINES
+    Return
+        ERROR if any line was not in the proper format (tabular, comma-delimited)
+        samplesheet as a dictionary
+    """
+    samplesheet = {}
+    file_read = file_read.splitlines()
+    for line in file_read:
+        if line.startswith("["):
+            section = line.split(',')[0].lstrip("[").rstrip("]")
+            samplesheet[section] = {}
+            continue
+        if not line or re.match("^,+$", line):
+            # Empty/Filler/Artifact lines with no info
+            continue
+        if section in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
+            # Data is tabular; append as list of lists until next header
+            if not isinstance(samplesheet[section], list):
+                samplesheet[section] = []
+            samplesheet[section].append(line)
+        else:
+            # Data is processed as key: value before adding it to dictionary
+            line = line.split(",")
+            try:
+                # Sometimes there are empty lines (e.g. READS values)
+                samplesheet[section][line[0].strip()] = line[1].strip() if len(line) > 1 else ""
+            except IndexError:
+                return {"ERROR": wetlab.config.ERROR_SAMPLE_SHEET_HAS_INVALID_LINES}
+    return samplesheet
+
 
 def validate_userid_in_user_iem_file(file_read, user_id_list):
     """
@@ -29,37 +83,20 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         userids with the ids found
     """
     users = {}
-    lines = file_read.split("\n")
-    data_section_found = False
-    description_index = False
-    userid_names, invalid_names = [], []
-    for line in lines:
-        line = line.rstrip()
-        if line == "":
-            continue
-        if "[Data]" in line:
-            data_section_found = True
-            continue
-        if data_section_found:
-            line = line.split(",")
-            if not description_index:
-                try:
-                    description_index = line.index("Description")
-                    continue
-                except Exception:
-                    users["ERROR"] = (
+    samplesheet = file_read_to_dictionary(file_read)
+    if "ERROR" in samplesheet:
+        return samplesheet
+
+    data = get_tabular_data(samplesheet, header_includes="Description")
+    if not data:
+        users["ERROR"] = (
                         wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_DESCRIPTION_FIELD
                     )
-                    return users
-            else:
-                try:
-                    u_name = line[description_index]
-                except Exception:
-                    continue
-                if u_name in user_id_list:
-                    userid_names.append(u_name)
-                else:
-                    invalid_names.append(u_name)
+        return users
+    users_in_sample_sheet = get_column_from_tabular_data(data, "Description")
+
+    userid_names = [user for user in users_in_sample_sheet if user in user_id_list]
+    invalid_names = [user for user in users_in_sample_sheet if user not in user_id_list]
 
     if len(invalid_names) > 0:
         invalid_names = list(set(invalid_names))
@@ -68,6 +105,7 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         )
         users["ERROR"] = invalid_names
         return users
+    
     users["user_ids"] = list(set(userid_names))
     return users
 
@@ -90,31 +128,43 @@ def delete_stored_file(input_file):
     return False
 
 
-def get_adapters(file_lines):
-    adapter1 = ""
-    adapter2 = ""
-    # For accepting characters like spanish characters.
-    for line in file_lines:
-        if line == "":
+def get_adapters(samplesheet: dict) -> tuple[str, str]:
+    """
+    Get the adapters from the samplesheet (v1 | v2)
+    
+    Parameters
+    ----------
+    samplesheet : dict
+        User sample sheet read as a dictionary
+
+    Return
+    ------
+    adapters : tuple
+        tuple containing the values in order for adapter 1 and 2
+    """
+    for settings_name in wetlab.config.SETTINGS_SECTIONS_SAMPLE_SHEET:
+        settings = samplesheet.get(settings_name)
+        if not settings:
             continue
-        found_adapter = re.search("^Adapter", line)
-        if found_adapter:
-            adapter_code = line.split(",")[1]
-            if adapter1 == "":
-                adapter1 = adapter_code
+        for i in range(len(wetlab.config.ADAPTER_1_FIELD_NAMES)):
+            try:
+                adapter1 = samplesheet[wetlab.config.ADAPTER_1_FIELD_NAMES[i]]
+                adapter2 = samplesheet[wetlab.config.ADAPTER_2_FIELD_NAMES[i]]
+            except ValueError:
                 continue
-            else:
-                adapter2 = adapter_code
-                break
-        data_found = re.search(r"^\[Data]", line)
-        if data_found:
             break
+        else:
+            continue
+        break
+    else:
+        return "", ""
 
     return adapter1, adapter2
 
 
-def get_heading(file_lines):
-    """read the input variable and extract the heading row
+def get_row_from_tabular_data(tabular_data: list[list], index) -> list:
+    """
+    Get the data headers 
 
     Parameters
     ----------
@@ -126,39 +176,41 @@ def get_heading(file_lines):
     heading : list
         contain the values from heading row of file
     """
+    try:
+        return tabular_data[index]
+    except IndexError:
+        return []
 
-    # For accepting characters like spanish characters.
-    heading = []
-    for line in file_lines:
-        line = line.strip()
-        if line == "":
+
+def get_column_from_tabular_data(tabular_data: list[list], column_name: str, unique: bool=False) -> list:
+    """
+    Docstring for get_all_values_from_tabular_data
+    
+    :param tabular_data: Description
+    :type tabular_data: dict[list[list[str]]]
+    """
+    headers = tabular_data[0]
+    tabular_data = [row for row in tabular_data[1:]]
+    try:
+        column_index = headers.index(column_name)
+    except ValueError:
+        return []
+
+    values = [row[column_index] for row in tabular_data]
+    return list(set(values)) if unique else values
+
+def get_tabular_data(samplesheet: dict, header_includes="") -> list[list]:
+    for data_section in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
+        data = samplesheet.get(data_section, [])
+        if not data:
             continue
-        found_header = re.search("^Sample_ID,Sample_Name", line)
-        if found_header:
-            heading = line.split(",")
-            break
-    return heading
+        if header_includes and header_includes not in data[0]:
+            continue
+        break
+    return [row.split(',') for row in data]
 
 
-def get_index_adapter(file_lines):
-    """
-    Description :
-        get the indexes adapter information from the file_lines
-    Input:
-        file_lines  # sample sheet file converted to list of lines
-    Return:
-        index_adapters . List of the reads
-    """
-    index_adapters = ""
-    for line in file_lines:
-        if "Index Adapters" in line:
-            index_adapters = line.split(",")[1].replace('"', "")
-            break
-    # remove the \n or \r
-    return index_adapters.rstrip()
-
-
-def get_projects_in_sample_sheet(file_lines):
+def get_projects_in_sample_sheet(samplesheet) -> list:
     """
     Description :
         get the project names defined from the file_lines
@@ -167,50 +219,32 @@ def get_projects_in_sample_sheet(file_lines):
     Return:
         project_name_list
     """
-    header_found = False
-    project_list = []
-    for line in file_lines:
-        line = line.rstrip()
-        if line == "":
-            continue
-        found_header = re.search("^Sample_ID,Sample_Name", line)
-        if found_header:
-            header_found = True
-            heading = line.split(",")
-            index_project_name = heading.index("Sample_Project")
-            continue
-        if header_found:
-            try:
-                project_list.append(line.split(",")[index_project_name])
-            except Exception:
-                continue
-    project_name_list = list(set(project_list))
-    return project_name_list
+    data = get_tabular_data(samplesheet)
+    projects = get_column_from_tabular_data(data, 'Sample_Project', unique=True)
+    return projects
 
-
-def get_reads(file_lines):
+def get_reads(samplesheet: dict) -> list[str, str]:
     """
     Description :
-        get the reads information from the file_lines
+        get the reads information from the samplesheet
     Input:
-        file_lines  # sample sheet file converted to list of lines
+        samplesheet  # samplesheet file converted to dictionary
     Return:
         reads . List of the reads
     """
-    read_found = False
+    reads_section = samplesheet.get("Reads")
     reads = []
-    for line in file_lines:
-        if "[Reads]" in line:
-            read_found = True
-            continue
-        if "[Settings]" in line:
+    for key, value in reads_section.items():
+        if not value:
+            # Sample sheets format for read is inconsistent - V1 accepts different format for read lengths
+            reads = list(reads_section.keys())
             break
-        if read_found and re.search(r"^\w+", line):
-            reads.append(line.split(",")[0])
+        if "Read" in key:
+            reads.append(value)
     return reads
 
 
-def get_samples_in_sample_sheet(file_lines):
+def get_samples_in_sample_sheet(samplesheet: dict) -> dict:
     """
     Description :
         get the sample information from the file_lines
@@ -221,34 +255,16 @@ def get_samples_in_sample_sheet(file_lines):
         is a list for each sample row
     """
     samples_dict = {}
-    samples_dict["samples"] = []
-    samples_dict["sample_data"] = []
-    header_found = False
-    for line in file_lines:
-        line = line.rstrip()
-        if line == "":
-            continue
-        found_header = re.search("^Sample_ID,Sample_Name", line)
-        if found_header:
-            header_found = True
-            samples_dict["heading"] = line.split(",")
-            index_sample_name = samples_dict["heading"].index("Sample_Name")
-            continue
-            # found the index for projects
-        if header_found:
-            line_split = line.split(",")
-            try:
-                sample_name = line_split[index_sample_name].strip()
-            except Exception:
-                continue
-            if sample_name == "":
-                continue
-            data = []
-            for item in line_split:
-                data.append(item.strip())
-            samples_dict["sample_data"].append(data)
-            samples_dict["samples"].append(sample_name)
+    data = get_tabular_data(samplesheet)
+
+    samples_dict["header"] = data[0] if len(data) > 1 else ""
+    samples_dict["samples"] = get_column_from_tabular_data(data, "Sample_Name")
+    samples_dict["sample_data"] = [get_row_from_tabular_data(data, i) for i in range(1, len(data))]
     return samples_dict
+
+def get_headers(samplesheet: dict) -> list:
+    data = get_tabular_data(samplesheet)
+    return data[0].split(',')
 
 
 def get_sample_sheet_data(file_read):
@@ -269,49 +285,25 @@ def get_sample_sheet_data(file_read):
         sample_sheet_data dictionary with the extracted information
     """
     sample_sheet_data = {}
-    # initialize data with empty values
+    samplesheet = file_read_to_dictionary(file_read)
+    # initialize header data
     for item in wetlab.config.FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5:
-        sample_sheet_data[item.lower()] = ""
+        sample_sheet_data[item.lower()] = samplesheet['Header'].get(item, "")
 
-    file_lines = file_read.split("\n")
-    for line in file_lines:
-        if "iemfileversion" in line.lower():
-            sample_sheet_data["iem_version"] = line.split(",")[1]
-            break
-    # get assay information
-    for line in file_lines:
-        if "Assay" in line:
-            sample_sheet_data["assay"] = line.split(",")[1]
-            break
-    # get index adapters information
-    # for line in file_lines :
-    #    if 'Index Adapters' in line :
-    #        sample_sheet_data['index_adapters'] = line.split(',')[1]
-    #        break
-    # get application information
-    for line in file_lines:
-        if "Application" in line:
-            sample_sheet_data["application"] = line.split(",")[1]
-            break
-    # get Instrument information
-    for line in file_lines:
-        if "Instrument Type" in line:
-            sample_sheet_data["instrument type"] = line.split(",")[1]
-            break
     # get adapters information
     sample_sheet_data["adapter1"], sample_sheet_data["adapter2"] = get_adapters(
-        file_lines
+        samplesheet
     )
     # get indexes adapters information
-    sample_sheet_data["index_adapters"] = get_index_adapter(file_lines)
+    sample_sheet_data["index_adapters"] = samplesheet.get('Headers', {}).get('Index Adapters', "")
     # get reads information
-    sample_sheet_data["reads"] = get_reads(file_lines)
+    sample_sheet_data["reads"] = get_reads(samplesheet)
     # get proyects in sheet_data
-    sample_sheet_data["proyects"] = get_projects_in_sample_sheet(file_lines)
+    sample_sheet_data["projects"] = get_projects_in_sample_sheet(samplesheet)
     # update sample sheet data
-    sample_sheet_data.update(get_samples_in_sample_sheet(file_lines))
+    sample_sheet_data.update(get_samples_in_sample_sheet(samplesheet))
     # include heading
-    sample_sheet_data["heading"] = get_heading(file_lines)
+    sample_sheet_data["header"] = get_headers(samplesheet)
     return sample_sheet_data
 
 
@@ -326,43 +318,20 @@ def get_sample_with_user_owner(sample_sheet_path):
         sample_user dictionary with the extracted information
     """
     sample_user = {}
-    header_found = False
     full_path = os.path.join(settings.MEDIA_ROOT, sample_sheet_path)
-    fh = open(full_path, "r")
-    for line in fh:
-        line = line.rstrip()
-        if line == "":
-            continue
-        found_header = re.search("^Sample_ID,Sample_Name,.*Description.*$", line)
-        if found_header:
-            header_found = True
-            sample_sheet_heading = line.split(",")
-            index_sample_name = sample_sheet_heading.index("Sample_Name")
-            try:
-                index_description = sample_sheet_heading.index("Description")
-            except Exception:
-                index_description = None
-            continue
-        if header_found:
-            line_split = line.split(",")
-            try:
-                sample_name = line_split[index_sample_name].strip()
-                if index_description is not None:
-                    user_id = line_split[index_description].strip()
-                else:
-                    user_id = None
-            except Exception:
-                continue
-            if sample_name == "":
-                continue
+    file_read = read_file_from_path(full_path)
+    samplesheet = file_read_to_dictionary(file_read)
+    # Retrieve tabular data with "Description" in the header
+    data = get_tabular_data(samplesheet, header_includes="Description")
+    sample_names = get_column_from_tabular_data(data, "Sample_Name")
+    user_ids = get_column_from_tabular_data(data, "Description")
 
-            sample_user[sample_name] = user_id
-    fh.close()
+    sample_user = {sample_names[i]: user_ids[i] for i in range(len(sample_names))}
     return sample_user
 
 
 def get_projects_in_run(in_file: str) -> dict:
-    """Funtion to check if the sample sheet has a valid heading. On valid file
+    """Funtion to check if the sample sheet has a valid header. On valid file
     get project names and the user names from description column
 
     Args:
@@ -371,37 +340,14 @@ def get_projects_in_run(in_file: str) -> dict:
     Returns:
         dict: dictionary with the projects or error message
     """
-    header_found = False
-    projects = {}
-    with open(in_file, "r") as fh:
-        for line in fh:
-            line = line.rstrip()
-            if line == "":
-                continue
-            if not header_found:
-                header = re.search("^Sample_ID,Sample_Name,.*Description.*$", line)
-                if header:
-                    # match line with the header
-                    # look for projects and description indexes
-                    if not "Sample_Project" and "Description" not in line:
-                        break
-                    split_line = line.split(",")
-                    p_index = split_line.index("Sample_Project")
-                    description_index = split_line.index("Description")
-                    header_found = True
-                    continue
-            else:
-                if line.startswith("["):
-                    # Jumped to next section - break search
-                    break
-                # ignore the empty lines separated by commas
-                valid_line = re.search(r"^\w+", line)
-                if not valid_line:
-                    continue
-                # store the project name and the user name (Description) inside projects dict
-                projects[line.split(",")[p_index]] = line.split(",")[description_index]
+    file_read = read_file_from_path(in_file)
+    samplesheet = file_read_to_dictionary(file_read)
+    data = get_tabular_data(samplesheet, header_includes="Description")
+    sample_projects = get_column_from_tabular_data(data, "Sample_Project")
+    user_ids = get_column_from_tabular_data(data, "Description")
+    projects = {sample_projects[i]: user_ids[i] for i in range(len(sample_projects))}
 
-    if not header_found:
+    if not data:
         return {"ERROR": wetlab.config.ERROR_SAMPLE_SHEET_HAS_INVALID_HEADING}
     if not projects:
         return {"ERROR": wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_PROJECTS}
@@ -420,25 +366,12 @@ def get_index_library_name(in_file):
     Output:
         library_value
     """
-    library_value = ""
-    # For accepting characters like spanish characters.
-    import codecs
 
-    fh = codecs.open(in_file, "r", "utf-8")
-    for line in fh:
-        line = line.rstrip()
-        if line == "":
-            continue
-        found_assay = re.search("^Assay", line)
-        if found_assay:
-            library_value = line.split(",")[1]
-            continue
-        found_adapters = re.search("^Index Adapters", line)
-        if found_adapters:
-            library_value = line.split(",")[1]
-            break
+    file_read = read_file_from_path(in_file)
+    samplesheet = file_read_to_dictionary(file_read)
+    header_values = samplesheet['Header']
+    library_value = header_values.get("Assay", "") or header_values.get("Index Adapters", "")
 
-    fh.close()
     return library_value
 
 
@@ -667,24 +600,6 @@ def read_all_lines_in_sample_sheet(sample_sheet):
     return read_lines
 
 
-def read_user_iem_file(in_file):
-    """
-    Description:
-        The function reads the input file and return the content in a variable
-
-    Return:
-        file_read
-    """
-    fh = codecs.open(in_file, "r", "utf-8")
-    try:
-        file_read = fh.read()
-        fh.close()
-        return file_read
-    except Exception:
-        fh.close()
-        return False
-
-
 def valid_user_iem_file(file_read):
     """
     Description:
@@ -701,33 +616,30 @@ def valid_user_iem_file(file_read):
     Return
         False if file cannot be read or do not have all information
     """
-    for section in wetlab.config.SECTIONS_IN_IEM_SAMPLE_SHEET:
-        if section not in file_read:
+    samplesheet = file_read_to_dictionary(file_read)
+    for section_name in samplesheet.keys():
+        if (
+        section_name not in wetlab.config.SECTIONS_IN_IEM_SAMPLE_SHEET
+        and
+        section_name not in wetlab.config.SECTIONS_IN_V2_SAMPLE_SHEET
+        ):
             return False
 
-    lines = file_read.split("\n")
-    data_section_found = False
     data_field_length = ""
     sample_number = 0
-    for line in lines:
-        line = line.rstrip()
-        if line == "":
-            continue
-        if "[Data]" in line:
-            data_section_found = True
-            continue
-        if data_section_found:
-            if data_field_length == "":
-                data_field_length = len(line.split(","))
-                continue
-            line_split = line.split(",")
-            # Allow at this step the Description field can be empth
-            if (
-                len(line_split) < data_field_length - 1
-                or len(line_split) > data_field_length
-            ):
-                return False
-            sample_number += 1
+    data = get_tabular_data(samplesheet, header_includes="Description")
+
+    # Check on data 
+    if not data:
+        return False
+
+    # Checks on data contents
+    data_field_length = len(data[0])
+    sample_number = len(data) - 1
+    if not all([len(row) - data_field_length for row in data]):
+        # All rows contain the same either the same 
+        return False
+    
     if sample_number == 0:
         return False
     return True

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -14,6 +14,18 @@ import wetlab.config
 # import wetlab.models
 
 
+def samplesheet_version(samplesheet: dict) -> str:
+    """
+    Return samplesheet version (1 or 2) as a string
+
+    Args:
+        samplesheet (dict): samplesheet
+
+    Returns:
+        str: "1" or "2"
+    """
+    return samplesheet.get("Header", {}).get("FileFormatVersion", "1")
+
 def read_file_from_path(file_path: str) -> str:
     """
     Read file from path, ensuring characters are not lost due to encoding
@@ -22,7 +34,7 @@ def read_file_from_path(file_path: str) -> str:
     :type file_path: str
     """
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, "r", encoding="utf-8-sig") as f:
             read_file = f.read()
     except Exception:
         return False
@@ -122,13 +134,14 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
     if "ERROR" in samplesheet:
         return samplesheet
 
-    data = get_tabular_data(samplesheet, header_includes="Description")
+    data = get_tabular_data(samplesheet)
+    iskylims_user_column = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
     if not data:
         users["ERROR"] = (
             wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_DESCRIPTION_FIELD
         )
         return users
-    users_in_sample_sheet = get_column_from_tabular_data(data, "Description")
+    users_in_sample_sheet = get_column_from_tabular_data(data, iskylims_user_column)
 
     userid_names = [user for user in users_in_sample_sheet if user in user_id_list]
     invalid_names = [user for user in users_in_sample_sheet if user not in user_id_list]
@@ -237,14 +250,18 @@ def get_column_from_tabular_data(
     return list(set(values)) if unique else values
 
 
-def get_tabular_data(samplesheet: dict, header_includes="") -> list[list]:
-    for data_section in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
-        data = samplesheet.get(data_section, [])
-        if not data:
-            continue
-        if header_includes and header_includes not in data[0]:
-            continue
-        break
+def get_tabular_data(samplesheet: dict) -> list[list]:
+    """
+    Get tabular data from a samplesheet.
+
+    Args:
+        samplesheet (dict): Samplesheet with the tabular data
+
+    Returns:
+        list[list]: Tabular data, in a nested list (Matrix N*M)
+    """
+    data_section = wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET.get(samplesheet_version(samplesheet), "")
+    data = samplesheet.get(data_section, [])
     return [row.split(",") for row in data]
 
 
@@ -365,10 +382,11 @@ def get_sample_with_user_owner(sample_sheet_path):
     full_path = os.path.join(settings.MEDIA_ROOT, sample_sheet_path)
     file_read = read_file_from_path(full_path)
     samplesheet = file_read_to_dictionary(file_read)
-    # Retrieve tabular data with "Description" in the header
-    data = get_tabular_data(samplesheet, header_includes="Description")
+    # Retrieve tabular data with the iskylims user in the header
+    data = get_tabular_data(samplesheet)
     sample_names = get_column_from_tabular_data(data, "Sample_Name")
-    user_ids = get_column_from_tabular_data(data, "Description")
+    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
+    user_ids = get_column_from_tabular_data(data, iskylims_user_column_id)
 
     sample_user = {sample_names[i]: user_ids[i] for i in range(len(sample_names))}
     return sample_user
@@ -386,9 +404,10 @@ def get_projects_in_run(in_file: str) -> dict:
     """
     file_read = read_file_from_path(in_file)
     samplesheet = file_read_to_dictionary(file_read)
-    data = get_tabular_data(samplesheet, header_includes="Description")
+    data = get_tabular_data(samplesheet)
     sample_projects = get_column_from_tabular_data(data, "Sample_Project")
-    user_ids = get_column_from_tabular_data(data, "Description")
+    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
+    user_ids = get_column_from_tabular_data(data, iskylims_user_column_id)
     projects = {sample_projects[i]: user_ids[i] for i in range(len(sample_projects))}
 
     if not data:
@@ -491,7 +510,7 @@ def create_unique_sample_id_values(in_file: str, index_file: str):
         last_line = f.readline().decode()
         index_number_str, index_letter = last_line.rstrip().split("-")
         index_number = int(index_number_str)
-    data = get_tabular_data(samplesheet, header_includes="Sample_ID")
+    data = get_tabular_data(samplesheet)
     for row in data[1:]:
         index_number += 1
         index_number = (
@@ -548,9 +567,9 @@ def set_user_names_in_sample_sheet(in_file, user_names):
     """
     file_read = read_file_from_path(in_file)
     samplesheet = file_read_to_dictionary(file_read)
-    data = get_tabular_data(samplesheet, header_includes="Description")
+    data = get_tabular_data(samplesheet)
     projects = get_column_from_tabular_data("Sample_Project")
-    descriptions_index = data[0].index("Description")
+    descriptions_index = data[0].index(wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet)))
     for i in range(1, len(data)):
         data[i][descriptions_index] = user_names[projects[i - 1]]
     success_writing = write_samplesheet_to_path(samplesheet, in_file)
@@ -620,7 +639,7 @@ def valid_user_iem_file(file_read: str) -> bool:
 
     data_field_length = ""
     sample_number = 0
-    data = get_tabular_data(samplesheet, header_includes="Description")
+    data = get_tabular_data(samplesheet)
 
     # Check on data
     if not data:

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -333,7 +333,7 @@ def get_sample_with_user_owner(sample_sheet_path):
         line = line.rstrip()
         if line == "":
             continue
-        found_header = re.search("^Sample_ID,Sample_Name", line)
+        found_header = re.search("^Sample_ID,Sample_Name,.*Description.*$", line)
         if found_header:
             header_found = True
             sample_sheet_heading = line.split(",")
@@ -379,7 +379,7 @@ def get_projects_in_run(in_file: str) -> dict:
             if line == "":
                 continue
             if not header_found:
-                header = re.search("^Sample_ID,Sample_Name,.+,Description.?", line)
+                header = re.search("^Sample_ID,Sample_Name,.*Description.*$", line)
                 if header:
                     # match line with the header
                     # look for projects and description indexes

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -26,6 +26,7 @@ def samplesheet_version(samplesheet: dict) -> str:
     """
     return samplesheet.get("Header", {}).get("FileFormatVersion", "1")
 
+
 def read_file_from_path(file_path: str) -> str:
     """
     Read file from path, ensuring characters are not lost due to encoding
@@ -135,7 +136,9 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         return samplesheet
 
     data = get_tabular_data(samplesheet)
-    iskylims_user_column = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
+    iskylims_user_column = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(
+        samplesheet_version(samplesheet)
+    )
     if not data:
         users["ERROR"] = (
             wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_DESCRIPTION_FIELD
@@ -260,7 +263,9 @@ def get_tabular_data(samplesheet: dict) -> list[list]:
     Returns:
         list[list]: Tabular data, in a nested list (Matrix N*M)
     """
-    data_section = wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET.get(samplesheet_version(samplesheet), "")
+    data_section = wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET.get(
+        samplesheet_version(samplesheet), ""
+    )
     data = samplesheet.get(data_section, [])
     return [row.split(",") for row in data]
 
@@ -385,7 +390,9 @@ def get_sample_with_user_owner(sample_sheet_path):
     # Retrieve tabular data with the iskylims user in the header
     data = get_tabular_data(samplesheet)
     sample_names = get_column_from_tabular_data(data, "Sample_Name")
-    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
+    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(
+        samplesheet_version(samplesheet)
+    )
     user_ids = get_column_from_tabular_data(data, iskylims_user_column_id)
 
     sample_user = {sample_names[i]: user_ids[i] for i in range(len(sample_names))}
@@ -406,7 +413,9 @@ def get_projects_in_run(in_file: str) -> dict:
     samplesheet = file_read_to_dictionary(file_read)
     data = get_tabular_data(samplesheet)
     sample_projects = get_column_from_tabular_data(data, "Sample_Project")
-    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet))
+    iskylims_user_column_id = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(
+        samplesheet_version(samplesheet)
+    )
     user_ids = get_column_from_tabular_data(data, iskylims_user_column_id)
     projects = {sample_projects[i]: user_ids[i] for i in range(len(sample_projects))}
 
@@ -421,8 +430,9 @@ def get_projects_in_run(in_file: str) -> dict:
 def get_index_library_name(in_file):
     """
     Description:
-        The function get the index library adapters. It searchs in the  assay value (used for version 4 of IEM sample sheet
-        and in hte Index Adapters on sample sheet version 5.
+        The function get the index library adapters. It searchs in the  assay
+        value (used for version 4 of IEM sample sheet
+        and in the Index Adapters on sample sheet version 5.
         If Index adapters is found they are used if not the assay value
     Input:
         in_file     # shample sheet file
@@ -569,7 +579,11 @@ def set_user_names_in_sample_sheet(in_file, user_names):
     samplesheet = file_read_to_dictionary(file_read)
     data = get_tabular_data(samplesheet)
     projects = get_column_from_tabular_data("Sample_Project")
-    descriptions_index = data[0].index(wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(samplesheet_version(samplesheet)))
+    descriptions_index = data[0].index(
+        wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(
+            samplesheet_version(samplesheet)
+        )
+    )
     for i in range(1, len(data)):
         data[i][descriptions_index] = user_names[projects[i - 1]]
     success_writing = write_samplesheet_to_path(samplesheet, in_file)

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -438,29 +438,18 @@ def update_library_kit_field(library_file_name, library_kit_name, library_name):
     return file_name_in_database
 
 
-def update_sample_sheet(in_file, experiment_name):
-    out_line = str("Experiment Name," + experiment_name + "\n")
-    fh_in = open(in_file, "r")
-    temp = os.path.join(settings.MEDIA_ROOT, "wetlab", "tmp.txt")
-    fh_out = open(temp, "w")
-    experiment_line_found = False
-    for line in fh_in:
-        # find experiment name line
-        found_experiment = re.search("^Experiment Name", line)
-        if found_experiment:
-            fh_out.write(out_line)
-            experiment_line_found = True
+def update_sample_sheet(in_file: str, experiment_name: str):
+    """
+    Update experiment name in samplesheet
 
-        elif line == "\n" and experiment_line_found is False:
-            fh_out.write(out_line)
-            fh_out.write("\n")
-            experiment_line_found = True
-        else:
-            fh_out.write(line)
-
-    fh_in.close()
-    fh_out.close()
-    os.rename(temp, in_file)
+    Args:
+        in_file (str): Path to samplesheet
+        experiment_name (str): experiment name
+    """
+    file_read = read_file_from_path(in_file)
+    samplesheet = file_read_to_dictionary(file_read)
+    samplesheet["Header"]["Experiment Name"] = experiment_name
+    write_samplesheet_to_path(in_file)
 
 
 def create_unique_sample_id_values(in_file: str, index_file: str):
@@ -487,7 +476,7 @@ def create_unique_sample_id_values(in_file: str, index_file: str):
     data = get_tabular_data(samplesheet, header_includes="Sample_ID")
     for row in data[1:]:
         index_number += 1
-        index_number = index_number % (10000) # Return only 4 last digits, effectively restarting at 10000
+        index_number = index_number % 10000 # Return only 4 last digits, effectively restarting at 10000
         if index_number == 0:
             # When index re-starts, we move on to the next letter
             index_letter_parts = list(index_letter)

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -28,6 +28,35 @@ def read_file_from_path(file_path: str) -> str:
         return False
     return read_file
 
+def write_samplesheet_to_path(samplesheet: dict, path: str) -> bool:
+    """
+    Write the samplesheet to a path.
+
+    Args:
+        samplesheet (dict): Sample sheet (As a dictionary)
+        path (str): Path to write the file to
+
+    Returns:
+        bool: True if no issue, False if any exception is raised
+    """
+
+    string_to_write = ""
+    for key, value in samplesheet.items():
+        string_to_write += f"[{key}]\n"
+        if key in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
+            string_to_write += f"{'\n'.join([','.join(row) for row in value])}\n"
+        else:
+            for row_header, element in value.items():
+                string_to_write += f"{row_header},{element}\n"
+    try:
+        with open(path, "w") as f:
+            f.write(string_to_write)
+        return True
+    except Exception:
+        return False
+            
+
+
 
 def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[list[str]]]:
     """
@@ -63,7 +92,7 @@ def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[l
             line = line.split(",")
             try:
                 # Sometimes there are empty lines (e.g. READS values)
-                samplesheet[section][line[0].strip()] = line[1].strip() if len(line) > 1 else ""
+                samplesheet[section][line[0].strip()] = ",".join(line[1:]).strip() if len(line) > 1 else ""
             except IndexError:
                 return {"ERROR": wetlab.config.ERROR_SAMPLE_SHEET_HAS_INVALID_LINES}
     return samplesheet
@@ -512,39 +541,17 @@ def set_user_names_in_sample_sheet(in_file, user_names):
         temp_sample_sheet # temporary sample sheet to store the information
                             it will replace the in_file
     Return:
-        True
+        Bool: True if successful writing, False otherwise
     """
-    found_sample_line = False
-    temp_sample_sheet = os.path.join(settings.MEDIA_ROOT, "wetlab", "tmp_file")
-    fh = open(in_file, "r")
-    fh_out_file = open(temp_sample_sheet, "w")
-    for line in fh:
-        if "Sample_ID" in line:
-            found_sample_line = True
-            line = line.rstrip()
-            project_index = line.split(",").index("Sample_Project")
-            description_index = line.split(",").index("Description")
-            fh_out_file.write(str(line + "\n"))
-            continue
-        if found_sample_line:
-            # discard the empty lines or the lines that contains empty lines separated by comma
-            if line == "\n" or re.search(r"^\W", line):
-                continue
-
-            data_line = line.split(",")
-            project_name = data_line[project_index]
-            data_line[description_index] = user_names[project_name]
-
-            new_line = ",".join(data_line)
-            fh_out_file.write(str(new_line + "\n"))
-
-        else:
-            fh_out_file.write(line)
-    fh.close()
-    fh_out_file.close()
-    os.rename(temp_sample_sheet, in_file)
-    return True
-
+    file_read = read_file_from_path(in_file)
+    samplesheet = file_read_to_dictionary(file_read)
+    data = get_tabular_data(samplesheet, header_includes="Description")
+    projects = get_column_from_tabular_data("Sample_Project")
+    descriptions_index = data[0].index("Description")
+    for i in range(1, len(data)):
+        data[i][descriptions_index] = user_names[projects[i -1]]
+    success_writing = write_samplesheet_to_path(samplesheet, in_file)
+    return success_writing
 
 def store_user_input_file(user_input_file):
     """
@@ -558,7 +565,7 @@ def store_user_input_file(user_input_file):
     Return
         stored_path_file contains the full path of the file and file_name
     """
-    # create thd directory if not exists
+    # create the directory if not exists
     template_dir = os.path.join(
         settings.MEDIA_ROOT, wetlab.config.LIBRARY_PREPARATION_SAMPLE_SHEET_DIRECTORY
     )
@@ -583,7 +590,7 @@ def store_user_input_file(user_input_file):
     return stored_path_file, file_name
 
 
-def valid_user_iem_file(file_read):
+def valid_user_iem_file(file_read: str) -> bool:
     """
     Description:
         The function check if the user IEM file has a valid format by checking the headings and

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
 # Generic imports
-import codecs
 import os
 import re
 import time
@@ -14,10 +13,11 @@ import wetlab.config
 
 # import wetlab.models
 
+
 def read_file_from_path(file_path: str) -> str:
     """
     Read file from path, ensuring characters are not lost due to encoding
-    
+
     :param file_path: Description
     :type file_path: str
     """
@@ -27,6 +27,7 @@ def read_file_from_path(file_path: str) -> str:
     except Exception:
         return False
     return read_file
+
 
 def write_samplesheet_to_path(samplesheet: dict, path: str) -> bool:
     """
@@ -54,11 +55,11 @@ def write_samplesheet_to_path(samplesheet: dict, path: str) -> bool:
         return True
     except Exception:
         return False
-            
 
 
-
-def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[list[str]]]:
+def file_read_to_dictionary(
+    file_read: str,
+) -> dict[str, dict[str, any] | list[list[str]]]:
     """
     Description:
         This function transforms a SampleSheet from string to dictionary,
@@ -76,7 +77,7 @@ def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[l
     file_read = file_read.splitlines()
     for line in file_read:
         if line.startswith("["):
-            section = line.split(',')[0].lstrip("[").rstrip("]")
+            section = line.split(",")[0].lstrip("[").rstrip("]")
             samplesheet[section] = {}
             continue
         if not line or re.match("^,+$", line):
@@ -92,7 +93,9 @@ def file_read_to_dictionary(file_read: str) -> dict[str, dict[str, any] | list[l
             line = line.split(",")
             try:
                 # Sometimes there are empty lines (e.g. READS values)
-                samplesheet[section][line[0].strip()] = ",".join(line[1:]).strip() if len(line) > 1 else ""
+                samplesheet[section][line[0].strip()] = (
+                    ",".join(line[1:]).strip() if len(line) > 1 else ""
+                )
             except IndexError:
                 return {"ERROR": wetlab.config.ERROR_SAMPLE_SHEET_HAS_INVALID_LINES}
     return samplesheet
@@ -119,8 +122,8 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
     data = get_tabular_data(samplesheet, header_includes="Description")
     if not data:
         users["ERROR"] = (
-                        wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_DESCRIPTION_FIELD
-                    )
+            wetlab.config.ERROR_SAMPLE_SHEET_DOES_NOT_HAVE_DESCRIPTION_FIELD
+        )
         return users
     users_in_sample_sheet = get_column_from_tabular_data(data, "Description")
 
@@ -134,7 +137,7 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         )
         users["ERROR"] = invalid_names
         return users
-    
+
     users["user_ids"] = list(set(userid_names))
     return users
 
@@ -160,7 +163,7 @@ def delete_stored_file(input_file):
 def get_adapters(samplesheet: dict) -> tuple[str, str]:
     """
     Get the adapters from the samplesheet (v1 | v2)
-    
+
     Parameters
     ----------
     samplesheet : dict
@@ -193,7 +196,7 @@ def get_adapters(samplesheet: dict) -> tuple[str, str]:
 
 def get_row_from_tabular_data(tabular_data: list[list], index) -> list:
     """
-    Get the data headers 
+    Get the data headers
 
     Parameters
     ----------
@@ -211,10 +214,12 @@ def get_row_from_tabular_data(tabular_data: list[list], index) -> list:
         return []
 
 
-def get_column_from_tabular_data(tabular_data: list[list], column_name: str, unique: bool=False) -> list:
+def get_column_from_tabular_data(
+    tabular_data: list[list], column_name: str, unique: bool = False
+) -> list:
     """
     Docstring for get_all_values_from_tabular_data
-    
+
     :param tabular_data: Description
     :type tabular_data: dict[list[list[str]]]
     """
@@ -228,6 +233,7 @@ def get_column_from_tabular_data(tabular_data: list[list], column_name: str, uni
     values = [row[column_index] for row in tabular_data]
     return list(set(values)) if unique else values
 
+
 def get_tabular_data(samplesheet: dict, header_includes="") -> list[list]:
     for data_section in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
         data = samplesheet.get(data_section, [])
@@ -236,7 +242,7 @@ def get_tabular_data(samplesheet: dict, header_includes="") -> list[list]:
         if header_includes and header_includes not in data[0]:
             continue
         break
-    return [row.split(',') for row in data]
+    return [row.split(",") for row in data]
 
 
 def get_projects_in_sample_sheet(samplesheet) -> list:
@@ -249,8 +255,9 @@ def get_projects_in_sample_sheet(samplesheet) -> list:
         project_name_list
     """
     data = get_tabular_data(samplesheet)
-    projects = get_column_from_tabular_data(data, 'Sample_Project', unique=True)
+    projects = get_column_from_tabular_data(data, "Sample_Project", unique=True)
     return projects
+
 
 def get_reads(samplesheet: dict) -> list[str, str]:
     """
@@ -288,12 +295,15 @@ def get_samples_in_sample_sheet(samplesheet: dict) -> dict:
 
     samples_dict["header"] = data[0] if len(data) > 1 else ""
     samples_dict["samples"] = get_column_from_tabular_data(data, "Sample_Name")
-    samples_dict["sample_data"] = [get_row_from_tabular_data(data, i) for i in range(1, len(data))]
+    samples_dict["sample_data"] = [
+        get_row_from_tabular_data(data, i) for i in range(1, len(data))
+    ]
     return samples_dict
+
 
 def get_headers(samplesheet: dict) -> list:
     data = get_tabular_data(samplesheet)
-    return data[0].split(',')
+    return data[0].split(",")
 
 
 def get_sample_sheet_data(file_read):
@@ -317,14 +327,16 @@ def get_sample_sheet_data(file_read):
     samplesheet = file_read_to_dictionary(file_read)
     # initialize header data
     for item in wetlab.config.FIELDS_IN_SAMPLE_SHEET_HEADER_IEM_VERSION_5:
-        sample_sheet_data[item.lower()] = samplesheet['Header'].get(item, "")
+        sample_sheet_data[item.lower()] = samplesheet["Header"].get(item, "")
 
     # get adapters information
     sample_sheet_data["adapter1"], sample_sheet_data["adapter2"] = get_adapters(
         samplesheet
     )
     # get indexes adapters information
-    sample_sheet_data["index_adapters"] = samplesheet.get('Headers', {}).get('Index Adapters', "")
+    sample_sheet_data["index_adapters"] = samplesheet.get("Headers", {}).get(
+        "Index Adapters", ""
+    )
     # get reads information
     sample_sheet_data["reads"] = get_reads(samplesheet)
     # get proyects in sheet_data
@@ -398,8 +410,10 @@ def get_index_library_name(in_file):
 
     file_read = read_file_from_path(in_file)
     samplesheet = file_read_to_dictionary(file_read)
-    header_values = samplesheet['Header']
-    library_value = header_values.get("Assay", "") or header_values.get("Index Adapters", "")
+    header_values = samplesheet["Header"]
+    library_value = header_values.get("Assay", "") or header_values.get(
+        "Index Adapters", ""
+    )
 
     return library_value
 
@@ -465,9 +479,9 @@ def create_unique_sample_id_values(in_file: str, index_file: str):
     samplesheet = file_read_to_dictionary(file_read)
 
     with open(index_file, "r") as f:
-        try:  # catch OSError in case of a one line file 
+        try:  # catch OSError in case of a one line file
             f.seek(-2, os.SEEK_END)
-            while f.read(1) != b'\n':
+            while f.read(1) != b"\n":
                 f.seek(-2, os.SEEK_CUR)
         except OSError:
             f.seek(0)
@@ -477,15 +491,19 @@ def create_unique_sample_id_values(in_file: str, index_file: str):
     data = get_tabular_data(samplesheet, header_includes="Sample_ID")
     for row in data[1:]:
         index_number += 1
-        index_number = index_number % 10000 # Return only 4 last digits, effectively restarting at 10000
+        index_number = (
+            index_number % 10000
+        )  # Return only 4 last digits, effectively restarting at 10000
         if index_number == 0:
             # When index re-starts, we move on to the next letter
             index_letter_parts = list(index_letter)
             # Reverse order to
-            for i in [1,0]:
+            for i in [1, 0]:
                 ascii_index_letter = ord(index_letter_parts[i])
                 ascii_index_letter += 1
-                ascii_index_letter = ascii_index_letter if ascii_index_letter <= 90 else 65
+                ascii_index_letter = (
+                    ascii_index_letter if ascii_index_letter <= 90 else 65
+                )
                 index_letter_parts[i] = chr(ascii_index_letter)
                 if ascii_index_letter != 65:
                     break
@@ -494,7 +512,7 @@ def create_unique_sample_id_values(in_file: str, index_file: str):
         # Create unique sample ID and overwrite Sample_ID
         sample_unique_id = f"{str(index_number).zfill(4)}-{index_letter}"
         row[0] = sample_unique_id
-    
+
     # Dump the index value to file
     with open(index_file, "w") as f:
         f.write(sample_unique_id)
@@ -531,9 +549,10 @@ def set_user_names_in_sample_sheet(in_file, user_names):
     projects = get_column_from_tabular_data("Sample_Project")
     descriptions_index = data[0].index("Description")
     for i in range(1, len(data)):
-        data[i][descriptions_index] = user_names[projects[i -1]]
+        data[i][descriptions_index] = user_names[projects[i - 1]]
     success_writing = write_samplesheet_to_path(samplesheet, in_file)
     return success_writing
+
 
 def store_user_input_file(user_input_file):
     """
@@ -591,9 +610,8 @@ def valid_user_iem_file(file_read: str) -> bool:
     samplesheet = file_read_to_dictionary(file_read)
     for section_name in samplesheet.keys():
         if (
-        section_name not in wetlab.config.SECTIONS_IN_IEM_SAMPLE_SHEET
-        and
-        section_name not in wetlab.config.SECTIONS_IN_V2_SAMPLE_SHEET
+            section_name not in wetlab.config.SECTIONS_IN_IEM_SAMPLE_SHEET
+            and section_name not in wetlab.config.SECTIONS_IN_V2_SAMPLE_SHEET
         ):
             return False
 
@@ -601,7 +619,7 @@ def valid_user_iem_file(file_read: str) -> bool:
     sample_number = 0
     data = get_tabular_data(samplesheet, header_includes="Description")
 
-    # Check on data 
+    # Check on data
     if not data:
         return False
 
@@ -609,9 +627,9 @@ def valid_user_iem_file(file_read: str) -> bool:
     data_field_length = len(data[0])
     sample_number = len(data) - 1
     if not all([len(row) - data_field_length for row in data]):
-        # All rows contain the same either the same 
+        # All rows contain the same either the same
         return False
-    
+
     if sample_number == 0:
         return False
     return True

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -45,7 +45,10 @@ def write_samplesheet_to_path(samplesheet: dict, path: str) -> bool:
     for key, value in samplesheet.items():
         string_to_write += f"[{key}]\n"
         if key in wetlab.config.TABULAR_DATA_SECTIONS_SAMPLE_SHEET:
-            string_to_write += f"{'\n'.join([','.join(row) for row in value])}\n"
+            delimiter = "\n"
+            string_to_write += (
+                f"{delimiter.join([','.join(row) for row in value])}{delimiter}"
+            )
         else:
             for row_header, element in value.items():
                 string_to_write += f"{row_header},{element}\n"

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -379,7 +379,7 @@ def get_projects_in_run(in_file: str) -> dict:
             if line == "":
                 continue
             if not header_found:
-                header = re.search("^Sample_ID,Sample_Name", line)
+                header = re.search("^Sample_ID,Sample_Name,.+,Description.?", line)
                 if header:
                     # match line with the header
                     # look for projects and description indexes
@@ -391,6 +391,9 @@ def get_projects_in_run(in_file: str) -> dict:
                     header_found = True
                     continue
             else:
+                if line.startswith("["):
+                    # Jumped to next section - break search
+                    break
                 # ignore the empty lines separated by commas
                 valid_line = re.search(r"^\w+", line)
                 if not valid_line:

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -583,23 +583,6 @@ def store_user_input_file(user_input_file):
     return stored_path_file, file_name
 
 
-def read_all_lines_in_sample_sheet(sample_sheet):
-    """
-    Description:
-        The function reads the input file and return the content in a variable
-    Input:
-        sample_sheet    # location of sample sheet
-    Return:
-        read_lines
-    """
-    read_lines = []
-    if os.path.exists(sample_sheet):
-        fh = open(sample_sheet, "r")
-        read_lines = fh.readlines()
-        fh.close()
-    return read_lines
-
-
 def valid_user_iem_file(file_read):
     """
     Description:

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -592,12 +592,8 @@ def create_nextseq_run(request):
             update_info_proj.save()
         results.append(["runname", experiment_name])
         run_p.set_run_state("recorded")
-        file_read = wetlab.utils.samplesheet.read_file_from_path(
-            in_file
-        )
-        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(
-            file_read
-        )
+        file_read = wetlab.utils.samplesheet.read_file_from_path(in_file)
+        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(file_read)
         sample_names_and_data = wetlab.utils.samplesheet.get_samples_in_sample_sheet(
             samplesheet
         )

--- a/wetlab/views.py
+++ b/wetlab/views.py
@@ -592,11 +592,14 @@ def create_nextseq_run(request):
             update_info_proj.save()
         results.append(["runname", experiment_name])
         run_p.set_run_state("recorded")
-        sample_sheet_lines = wetlab.utils.samplesheet.read_all_lines_in_sample_sheet(
+        file_read = wetlab.utils.samplesheet.read_file_from_path(
             in_file
         )
+        samplesheet = wetlab.utils.samplesheet.file_read_to_dictionary(
+            file_read
+        )
         sample_names_and_data = wetlab.utils.samplesheet.get_samples_in_sample_sheet(
-            sample_sheet_lines
+            samplesheet
         )
         wetlab.utils.run.increase_reuse_if_samples_exists(
             sample_names_and_data["samples"]
@@ -3079,7 +3082,7 @@ def manage_library_preparation(request):
             data["full_path_file"],
             data["file_name"],
         ) = wetlab.utils.samplesheet.store_user_input_file(request.FILES["uploadfile"])
-        file_read = wetlab.utils.samplesheet.read_user_iem_file(data["full_path_file"])
+        file_read = wetlab.utils.samplesheet.read_file_from_path(data["full_path_file"])
         if not wetlab.utils.samplesheet.valid_user_iem_file(file_read):
             # Error found when extracting data from sample sheet
             data["ERROR"] = wetlab.config.ERROR_INVALID_FILE_FORMAT


### PR DESCRIPTION
This PR:
- Adds support for SampleSheetV2 (As long as the old [Data] header is present with the new header `[CustomCustomer_Data]`) ( `wetlab/utils/samplesheet.py`)
- Adds support for new sequencer addition (Fixed a bug in `core/models.py`)
- Adds support for MiSeq_100 XML completion tag AND  support for MiSeq_100 timestamps AND fixes error in setting cancelled statuses in sequencer_run_is_completed (`wetlab/utils/crontab_process.py`)
- Added new tags in config to support MiSeq_100 (`wetlab/config.py`)
- Adds new possible value `custom_description` (`wetlab/config.py`)

Also, completely re-factors samplesheet - functionality should remain (mostly) intact