### PR TITLE
Update install.sh strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enabled Docker internal networking for local test installation [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 - Opened Docker network to allow localhost MySQL connection when required [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 - Added test fixtures and installation updates for the new sequencer and SampleSheet v2 support, including admin test-group assignment and new sequencer bootstrap data. Closes [#388](https://github.com/BU-ISCIII/iskylims/issues/388) [#392](https://github.com/BU-ISCIII/iskylims/pull/392)
+- Refactored container installation flow to separate staged application install from runtime bootstrap tasks [#393](https://github.com/BU-ISCIII/iskylims/pull/393)
+- Updated Docker image build to stage application files at build time and run bootstrap tasks on container start/upgrade [#393](https://github.com/BU-ISCIII/iskylims/pull/393)
+- Replaced container cron runtime with supercronic and improved multi-container install configuration [#391](https://github.com/BU-ISCIII/iskylims/pull/391)
 
 #### Fixes
 
@@ -73,6 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed samplesheet parsing error [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 - Fixed logger inconsistency that prevented exceptions and error messages from being written to the update crontab log. Closes [#390](https://github.com/BU-ISCIII/iskylims/issues/390) [#392](https://github.com/BU-ISCIII/iskylims/pull/392)
 - Fixed wetlab crontab processing for the new sequencer, including run discovery, completion checks, RunInfo/RunParameters parsing updates, and SampleSheet v2 handling. Closes [#387](https://github.com/BU-ISCIII/iskylims/issues/387) [#392](https://github.com/BU-ISCIII/iskylims/pull/392)
+- Improved Podman compatibility and adjusted SELinux bind mount handling in production compose setup [#393](https://github.com/BU-ISCIII/iskylims/pull/393)
 
 #### Changed
 
@@ -87,7 +91,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - API create-sample-data Lab data mapping moved to core_config.LAB_REQUEST_ONTOLOGY_MAP [#377](https://github.com/BU-ISCIII/iskylims/pull/377)
 - Renamed `docker-compose.yml` to `docker-compose.test.yml` and `docker-compose.prod.yml` for test clarity [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 - Refactored Docker runtime handling when path is outside repository [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
-- Updated `docker_install.sh` with multiple reliability improvements [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
+- Updated `docker_install.sh` to `container_install.sh` with multiple reliability improvements [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 - Updated upgrade scripts documentation to include execution order information and docker upgrade clarifications [#389](https://github.com/BU-ISCIII/iskylims/pull/389)
 
 #### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,11 @@ ARG INSTALL_TYPE=dep
 ARG GIT_REVISION=main
 ARG INSTALL_CONF=conf/docker_test_settings.txt
 
-# Execute the dependency stage only; app migrations run when the container is up.
+# Prepare dependencies and stage the application tree in the image so the
+# container can restart without rerunning install-time file generation.
 ENV SKIP_SYSTEM_PACKAGES=1
 RUN /bin/bash install.sh --install dep --git_revision $GIT_REVISION --conf $INSTALL_CONF --skip_apache_restart
+RUN /bin/bash install.sh --stage install --git_revision $GIT_REVISION --conf $INSTALL_CONF --skip_apache_restart
 # Use the virtualenv created by install.sh
 ENV PATH="${APP_INSTALL_PATH}/virtualenv/bin:${PATH}"
 

--- a/LEAME.md
+++ b/LEAME.md
@@ -128,6 +128,8 @@ bash container_install.sh --test --script migrate_optional_values
 
 Cuando el script termine, abre `http://localhost:8001` y crea el superusuario de Django cuando te lo pida.
 
+La imagen ahora incluye el arbol de la aplicacion ya preparado dentro de `${APP_INSTALL_PATH}`. Por tanto, los contenedores de prueba pueden recrearse o reiniciarse sin volver a ejecutar la instalacion de ficheros; `container_install.sh` solo lanza las tareas de bootstrap de BD, scripts opcionales y estaticos.
+
 ### Contenedor de produccion
 
 Despliega el contenedor de iSkyLIMS contra servicios MySQL/Samba externos:
@@ -154,6 +156,8 @@ Despliega el contenedor de iSkyLIMS contra servicios MySQL/Samba externos:
     ```
 
 3. Si es una instalacion nueva, crea el superusuario cuando se solicite y completa la configuracion de Samba en la UI.
+
+Las imagenes de produccion ahora incorporan la aplicacion iSkyLIMS ya preparada. Un reinicio del host o la recreacion del contenedor ya no requiere reinstalar la aplicacion; `container_install.sh` solo ejecuta tareas de bootstrap en runtime, como migraciones, scripts/fixtures opcionales, creacion del superusuario en la primera instalacion y `collectstatic`.
 
 UID/GID del usuario de ejecucion del contenedor (por defecto `1212:1212`):
 
@@ -244,7 +248,7 @@ Durante `container_install.sh`, el fichero `conf/iskylims_apache_reverse_proxy.c
 
 Si necesitas otra raiz de instalacion, define `INSTALL_PATH` en el fichero de configuracion o exporta `APP_INSTALL_PATH` antes de ejecutar `container_install.sh`.
 
-`container_install.sh` crea `${APP_INSTALL_PATH}/conf` y `/var/log/local/apache` antes de `compose up`, copia ahi `conf/iskylims_apache_reverse_proxy.conf`, exporta `APP_INSTALL_PATH` a Compose y despues ejecuta `install.sh` dentro del contenedor `app`. `install.sh` crea `${INSTALL_PATH}/logs`, `${INSTALL_PATH}/documents` y ejecuta `collectstatic`, mientras que el contenedor `apache` sigue escribiendo sus logs en el path del host `/var/log/local/apache`.
+`container_install.sh` crea `${APP_INSTALL_PATH}/conf` y `/var/log/local/apache` antes de `compose up`, copia ahi `conf/iskylims_apache_reverse_proxy.conf`, exporta `APP_INSTALL_PATH` a Compose y despues ejecuta `install.sh --bootstrap ...` dentro del contenedor `app`. La imagen del contenedor ya contiene el proyecto Django y el virtualenv preparados dentro de `${APP_INSTALL_PATH}`; el bootstrap aplica migraciones, scripts/fixtures opcionales y refresca `${INSTALL_PATH}/static`, mientras que el contenedor `apache` sigue escribiendo sus logs en el path del host `/var/log/local/apache`.
 
 Nota SELinux para pre-produccion y produccion:
 
@@ -285,7 +289,7 @@ Re-despliega el contenedor de aplicacion contra una base de datos existente sin 
 bash container_install.sh --install_conf conf/my_prod_settings.txt --action upgrade
 ```
 
-La actualizacion reconstruye/reinicia el contenedor y ejecuta `install.sh` dentro del contenedor, que regenera migraciones, las aplica con `--fake-initial` y evita cargar superusuario/datos demo/prueba.
+La actualizacion reconstruye/reinicia el contenedor y ejecuta `install.sh --bootstrap upgrade` dentro del contenedor. Los ficheros de la aplicacion ya van incorporados en la nueva imagen; la fase de bootstrap aplica migraciones con `--fake-initial`, refresca los estaticos y evita cargar superusuario/datos demo/prueba.
 
 ### Actualizacion del despliegue Docker v3.0.0 a 3.1.0
 
@@ -370,6 +374,8 @@ iSkyLIMS se instala en `/opt/iskylims` por defecto. El script `install.sh` gesti
 - `dep`: instala dependencias del sistema y de Python (requiere sudo).
 - `app`: despliega el codigo, actualiza ajustes, ejecuta migraciones y collectstatic (sin sudo).
 - `full`: ejecuta ambos pasos.
+
+La separacion interna entre preparacion de ficheros y bootstrap se usa solo para las imagenes de contenedor. En bare-metal no cambian los comandos operativos: `--install` y `--upgrade` siguen ejecutando el flujo completo de dependencias, aplicacion y base de datos descrito aqui.
 
 Ejemplos:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ bash container_install.sh --test --script migrate_optional_values 2>&1 | tee tes
 
 When the script finishes, open `http://localhost:8001` and follow the prompt to create the Django superuser.
 
+The image now includes the staged application tree under `${APP_INSTALL_PATH}`. Test containers can therefore be recreated or restarted without rerunning the file installation step; only DB/bootstrap tasks are executed by `container_install.sh`.
+
 ### Production container
 
 Deploy the iSkyLIMS container against external MySQL/Samba services:
@@ -152,6 +154,8 @@ Deploy the iSkyLIMS container against external MySQL/Samba services:
     ```
 
 3. If this is a fresh install, create the Django superuser when prompted and complete the Samba configuration in the UI.
+
+Production images now bake the staged iSkyLIMS application into the image itself. Host reboots or container recreation no longer require rerunning the app installation step; `container_install.sh` only performs runtime bootstrap tasks such as migrations, optional fixtures/scripts, superuser creation on first install, and `collectstatic`.
 
 UID/GID for the container runtime user (default `1212:1212`):
 
@@ -242,7 +246,7 @@ During `container_install.sh`, the file `conf/iskylims_apache_reverse_proxy.conf
 
 If you need a different runtime root, set `INSTALL_PATH` in the install config file or export `APP_INSTALL_PATH` before running `container_install.sh`.
 
-`container_install.sh` creates `${APP_INSTALL_PATH}/conf` and `/var/log/local/apache` before `compose up`, copies `conf/iskylims_apache_reverse_proxy.conf` there, passes `APP_INSTALL_PATH` into Compose, and then runs `install.sh` inside the `app` container. `install.sh` creates `${INSTALL_PATH}/logs`, `${INSTALL_PATH}/documents`, and runs `collectstatic`, while the Apache container keeps using the host log path `/var/log/local/apache`.
+`container_install.sh` creates `${APP_INSTALL_PATH}/conf` and `/var/log/local/apache` before `compose up`, copies `conf/iskylims_apache_reverse_proxy.conf` there, passes `APP_INSTALL_PATH` into Compose, and then runs `install.sh --bootstrap ...` inside the `app` container. The container image already contains the staged Django project and virtualenv under `${APP_INSTALL_PATH}`; the bootstrap step applies migrations, optional scripts/fixtures, and refreshes `${INSTALL_PATH}/static`, while the Apache container keeps using the host log path `/var/log/local/apache`.
 
 SELinux note for pre-production and production:
 
@@ -283,7 +287,7 @@ Re-deploy the application container against an existing production database with
 bash container_install.sh --install_conf conf/my_prod_settings.txt --action upgrade 2>&1 | tee ./iskylims_docker_install_$(date +%Y%m%d_%H%M%S).log
 ```
 
-The upgrade path rebuilds/restarts the container and runs `install.sh` inside the app container, which regenerates migrations, applies them with `--fake-initial`, and skips superuser/demo/test data loading.
+The upgrade path rebuilds/restarts the container and runs `install.sh --bootstrap upgrade` inside the app container. The app files are already baked into the rebuilt image; the bootstrap phase applies migrations with `--fake-initial`, refreshes static files, and skips superuser/demo/test data loading.
 
 ### Upgrade docker deployment v3.0.0 to 3.1.0
 
@@ -357,6 +361,8 @@ iSkyLIMS is installed to `/opt/iskylims` by default. The single `install.sh` scr
 - `dep`: install system and Python dependencies (requires sudo).
 - `app`: deploy iSkyLIMS code, update settings, run migrations, and collect static files (no sudo needed).
 - `full`: run both stages in sequence.
+
+The staged/bootstrap split added for container images is internal. Bare-metal commands do not change: `--install` and `--upgrade` still run the complete dependency, application, and database workflow documented here.
 
 Examples:
 

--- a/container_install.sh
+++ b/container_install.sh
@@ -526,7 +526,7 @@ cleanup_stale_test_containers
 
 print_local_source_diagnostics
 print_existing_artifact_diagnostics
-echo "Deploying containers (compose file: $compose_file) with INSTALL_TYPE=dep and GIT_REVISION=$git_revision..."
+echo "Deploying containers (compose file: $compose_file) with a pre-staged app image and GIT_REVISION=$git_revision..."
 mkdir -p "$app_install_path/conf" "/var/log/local/apache"
 if [ -f "$repo_root/conf/iskylims_apache_reverse_proxy.conf" ]; then
     copy_with_podman_fallback \
@@ -577,17 +577,17 @@ if [ "$run_script" = true ]; then
 fi
 
 if [ "$action" = "upgrade" ]; then
-    echo "Running install.sh upgrade inside the container"
-    engine_exec exec -it "$app_container" bash -c "cd $app_repo_path && bash install.sh --upgrade app --git_revision \"$git_revision\" --conf \"$install_conf_container\" --skip_apache_restart$script_args_before$script_args_after"
+    echo "Running install.sh bootstrap inside the container (upgrade mode)"
+    engine_exec exec -it "$app_container" bash -c "cd $app_repo_path && bash install.sh --bootstrap upgrade --git_revision \"$git_revision\" --conf \"$install_conf_container\" --skip_apache_restart$script_args_before$script_args_after"
 else
-    echo "Running install.sh install inside the container"
-    engine_exec exec -it "$app_container" bash -c "cd $app_repo_path && bash install.sh --install app --git_revision \"$git_revision\" --conf \"$install_conf_container\" --skip_apache_restart$script_args_before$script_args_after"
+    echo "Running install.sh bootstrap inside the container (install mode)"
+    engine_exec exec -it "$app_container" bash -c "cd $app_repo_path && bash install.sh --bootstrap install --git_revision \"$git_revision\" --conf \"$install_conf_container\" --skip_apache_restart$script_args_before$script_args_after"
 fi
 
-print_container_source_diagnostics "Container diagnostics after install.sh:"
+print_container_source_diagnostics "Container diagnostics after bootstrap:"
 
 if ! engine_exec exec -it "$app_container" test -f "$app_install_path/manage.py"; then
-    echo "Error: $app_install_path/manage.py not found after install.sh. Showing logs:"
+    echo "Error: $app_install_path/manage.py not found after bootstrap. Showing logs:"
     engine_exec logs --tail 200 "$app_container"
     exit 1
 fi

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,9 +46,9 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /usr/share/zoneinfo:/usr/share/zoneinfo
-      - /var/log/local/apps/iskylims:${APP_INSTALL_PATH:-/opt/iskylims}/logs:Z
+      - /var/log/local/apps/iskylims:${APP_INSTALL_PATH:-/opt/iskylims}/logs:z
       - iskylims_documents:${APP_INSTALL_PATH:-/opt/iskylims}/documents
-      - iskylims_static:${APP_INSTALL_PATH:-/opt/iskylims}/static:Z
+      - iskylims_static:${APP_INSTALL_PATH:-/opt/iskylims}/static:z
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ usage : $0 --upgrade --git_revision --conf
     Optional input data:
     --install       | Install iskylims full/dep/app
     --upgrade       | Upgrade iskylims full/dep/app
+    --stage         | Stage app files only (install/upgrade) without DB work. Internal/container use.
+    --bootstrap     | Run DB/bootstrap steps only (install/upgrade) against an existing staged app. Internal/container use.
     --git_revision  | Git revision name to run (branch, tag, commit SHA, or 'current' to use copied local sources as-is)
     --conf          | Select custom configuration file. Default: ./install_settings.txt
     --tables        | Load the first inital tables (from conf folder)
@@ -34,6 +36,12 @@ Examples:
 
     Upgrade running migration script and update initial tables
     $0 --upgrade full --script <migration_script> --tables
+
+    Stage application files during a container image build
+    $0 --stage install --git_revision main --conf conf/docker_production_settings.txt
+
+    Bootstrap database/static using an already staged container image
+    $0 --bootstrap upgrade --git_revision main --conf conf/docker_production_settings.txt
 
     Make adjustments for apps renaming in upgrade 2.3.0 to 2.3.1
     $0 --upgrade full --ren_app --script <migration_script> --tables
@@ -331,6 +339,20 @@ check_requirements() {
     fi
 }
 
+check_stage_requirements() {
+    log_section "Checking requirements for staged app preparation"
+    python_check
+    log_info "Valid version of Python"
+}
+
+check_bootstrap_requirements() {
+    log_section "Checking requirements for application bootstrap"
+    python_check
+    log_info "Valid version of Python"
+    db_check
+    log_info "Successful check for database"
+}
+
 # rename_apps_if_needed: handles legacy app renaming and DB/migration adjustments when --ren_app is provided.
 rename_apps_if_needed() {
     if [ $ren_app != true ]; then
@@ -558,6 +580,20 @@ run_django_deploy() {
     fi
 }
 
+refresh_static_files() {
+    echo "Deleting static files..."
+    if [ -d "$INSTALL_PATH/static" ]; then
+        if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$INSTALL_PATH/static"; then
+            echo "Static directory is a mount point. Skipping delete."
+        else
+            rm -rf "$INSTALL_PATH/static" || echo "Skipping static removal (busy)."
+        fi
+    fi
+    echo "Running collect statics..."
+    python manage.py collectstatic --noinput
+    echo "Done collect statics"
+}
+
 # sync_requirements_file: copy repository requirements into the target installation path.
 sync_requirements_file() {
     mkdir -p $INSTALL_PATH/conf
@@ -717,6 +753,18 @@ upgrade_application_files() {
 
     rename_apps_if_needed
 
+    stage_upgrade_application_files
+    bootstrap_application_runtime "upgrade"
+
+    log_section "Successfuly upgrade of iSKyLIMS version: ${APP_VERSION}"
+}
+
+# stage_upgrade_application_files: sync code/config into INSTALL_PATH without DB work.
+stage_upgrade_application_files() {
+    if [ ! -d $INSTALL_PATH ]; then
+        abort_install "Unable to start the upgrade. Folder $INSTALL_PATH does not exist."
+    fi
+
     echo "Copying files to installation folder"
     rsync -rlv conf/ $INSTALL_PATH/conf/
     rsync -rlv --fuzzy --delay-updates --delete-delay \
@@ -737,25 +785,19 @@ upgrade_application_files() {
     update_settings_and_urls
     prepare_documents_structure
 
-    run_django_deploy "upgrade"
-    echo "Deleting static files..."
-    if [ -d "$INSTALL_PATH/static" ]; then
-        if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$INSTALL_PATH/static"; then
-            echo "Static directory is a mount point. Skipping delete."
-        else
-            rm -rf "$INSTALL_PATH/static" || echo "Skipping static removal (busy)."
-        fi
-    fi
-    echo "Running collect statics..."
-    python manage.py collectstatic
-    echo "Done collect statics"
-
     cd -
-    log_section "Successfuly upgrade of iSKyLIMS version: ${APP_VERSION}"
 }
 
 # install_application_files: deploy Django project files, update settings, and run initial migrations.
 install_application_files() {
+    stage_install_application_files
+    bootstrap_application_runtime "install"
+    log_section "Successfuly iSkyLIMS Installation version: ${APP_VERSION}"
+    echo "Installation completed"
+}
+
+# stage_install_application_files: copy app files into INSTALL_PATH without DB work.
+stage_install_application_files() {
     log_section "Starting iSkyLIMS install version: ${APP_VERSION}"
 
     user=${SUDO_USER:-$USER}
@@ -813,16 +855,31 @@ install_application_files() {
 
         update_settings_and_urls
 
-        run_django_deploy "install"
-
-        echo "Run collectstatic"
-        python manage.py collectstatic
-
         cd -
-
-        log_section "Successfuly iSkyLIMS Installation version: ${APP_VERSION}"
-        echo "Installation completed"
     fi
+}
+
+# bootstrap_application_runtime: run DB/bootstrap tasks against an already staged INSTALL_PATH.
+bootstrap_application_runtime() {
+    local mode="$1"
+
+    if [ ! -d "$INSTALL_PATH" ]; then
+        abort_install "Unable to bootstrap application. Folder $INSTALL_PATH does not exist."
+    fi
+
+    cd $INSTALL_PATH
+    ensure_virtualenv_ready
+    echo "activate the virtualenv"
+    source virtualenv/bin/activate
+
+    if [ ! -f "$INSTALL_PATH/manage.py" ]; then
+        abort_install "manage.py not found at $INSTALL_PATH/manage.py. Stage application files first."
+    fi
+
+    run_django_deploy "$mode"
+    refresh_static_files
+
+    cd -
 }
 
 # translate long options to short
@@ -837,6 +894,8 @@ do
     # OPTIONAL
         --install)      set -- "$@" -i ;;
         --upgrade)      set -- "$@" -u ;;
+        --stage)        set -- "$@" -j ;;
+        --bootstrap)    set -- "$@" -l ;;
         --script)       set -- "$@" -s ;;
         --script_before) set -- "$@" -p ;;
         --script_after) set -- "$@" -o ;;
@@ -866,6 +925,8 @@ install=true
 install_type="full"
 upgrade=false
 upgrade_type="full"
+workflow="standard"
+workflow_mode=""
 docker=false
 prefilled_tables="conf/first_install_tables.json"
 restart_apache=true
@@ -876,10 +937,11 @@ migration_script_before=()
 skip_tables=false
 
 # PARSE VARIABLE ARGUMENTS WITH getops
-options=":c:s:i:u:r:g:tdbkvhao:p:"
+options=":c:s:i:u:j:l:r:g:tdbkvhao:p:"
 while getopts $options opt; do
     case $opt in
         i ) 
+            workflow="standard"
             install=true
             upgrade=false
             if [[ "$OPTARG" == "full" || "$OPTARG" == "dep" || "$OPTARG" == "app" ]]; then
@@ -891,6 +953,7 @@ while getopts $options opt; do
             fi
             ;;
         u )
+            workflow="standard"
             install=false
             upgrade=true
             if [[ "$OPTARG" == "full" || "$OPTARG" == "dep" || "$OPTARG" == "app" ]]; then
@@ -898,6 +961,22 @@ while getopts $options opt; do
                 install_type=$OPTARG
             else
                 echo "Upgrade is not set to one valid option. Use: --upgrade full/app/dep"
+                exit 1
+            fi
+            ;;
+        j )
+            workflow="stage"
+            workflow_mode=$OPTARG
+            if [[ "$workflow_mode" != "install" && "$workflow_mode" != "upgrade" ]]; then
+                echo "Stage is not set to one valid option. Use: --stage install/upgrade"
+                exit 1
+            fi
+            ;;
+        l )
+            workflow="bootstrap"
+            workflow_mode=$OPTARG
+            if [[ "$workflow_mode" != "install" && "$workflow_mode" != "upgrade" ]]; then
+                echo "Bootstrap is not set to one valid option. Use: --bootstrap install/upgrade"
                 exit 1
             fi
             ;;
@@ -967,6 +1046,10 @@ if [ $upgrade == true ]; then
     operation="upgrade"
     operation_scope="$upgrade_type"
 fi
+if [ "$workflow" != "standard" ]; then
+    operation="$workflow_mode"
+    operation_scope="app"
+fi
 
 # Default to loading initial tables on installs unless explicitly skipped.
 if [ "$operation" = "install" ] && [ "$skip_tables" = false ] && [ "$tables" = false ]; then
@@ -977,6 +1060,26 @@ load_install_config
 PROJECT_NAME="${PROJECT_NAME:-iskylims}"
 checkout_git_revision
 user=${SUDO_USER:-$USER}
+
+if [ "$workflow" = "stage" ]; then
+    check_stage_requirements
+    if [ "$workflow_mode" = "install" ]; then
+        stage_install_application_files
+    else
+        stage_upgrade_application_files
+    fi
+    exit 0
+fi
+
+if [ "$workflow" = "bootstrap" ]; then
+    check_bootstrap_requirements
+    if [ "$workflow_mode" = "upgrade" ]; then
+        rename_apps_if_needed
+    fi
+    bootstrap_application_runtime "$workflow_mode"
+    exit 0
+fi
+
 check_requirements
 
 if [[ "$operation_scope" == "full" || "$operation_scope" == "dep" ]]; then

--- a/scripts/container_start.sh
+++ b/scripts/container_start.sh
@@ -13,16 +13,17 @@ GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-120}"
 GUNICORN_KEEPALIVE="${GUNICORN_KEEPALIVE:-5}"
 GUNICORN_THREADS="${GUNICORN_THREADS:-2}"
 
-WAIT_TIMEOUT_SECONDS=100
-wait_start="${SECONDS}"
+if [ ! -f "${APP_DIR}/manage.py" ]; then
+    echo "Application entrypoint not found at ${APP_DIR}/manage.py" >&2
+    ls -la "${APP_DIR}" >&2 || true
+    exit 1
+fi
 
-while [ ! -f "${APP_DIR}/manage.py" ]; do
-    if (( SECONDS - wait_start >= WAIT_TIMEOUT_SECONDS )); then
-        echo "Timed out after ${WAIT_TIMEOUT_SECONDS}s waiting for ${APP_DIR}/manage.py" >&2
-        exit 1
-    fi
-    sleep 2
-done
+if [ ! -f "${APP_DIR}/virtualenv/bin/activate" ]; then
+    echo "Virtualenv activation script not found at ${APP_DIR}/virtualenv/bin/activate" >&2
+    ls -la "${APP_DIR}/virtualenv" >&2 || true
+    exit 1
+fi
 
 source "${APP_DIR}/virtualenv/bin/activate"
 


### PR DESCRIPTION

This PR updates the container deployment flow so application files are staged into the image at build time, while runtime bootstrap tasks are executed separately when containers start or are upgraded. The goal is to make recreated or restarted containers come up without rerunning the full file installation step.

Main changes:

- Split install.sh into two internal workflows:
--stage: prepares application files only
--bootstrap: runs runtime tasks only, including migrations and collectstatic

- Updated the Dockerfile to run staged app installation during image build.
- Updated container_install.sh to execute install.sh --bootstrap install|upgrade inside containers instead of reinstalling app files.
- Added safer static refresh handling and centralized Apache group detection in install.sh.
- Improved Podman compatibility when copying the Apache reverse proxy config.
- Updated docker-compose.prod.yml to mount Apache config from ${APP_INSTALL_PATH} and persist Apache logs on the host.
- Refreshed README.md and LEAME.md to document the new container behavior and clarify that bare-metal commands remain unchanged.
