### PR TITLE
Fix dash to dot issue in samplesheets when parsing usernames from project IDs

### DIFF
--- a/wetlab/utils/common.py
+++ b/wetlab/utils/common.py
@@ -503,7 +503,10 @@ def open_log(config_file):
     logger = logging.getLogger()
     return logger
 
-def get_all_string_replacement_combinations(string: str, old: str, new: str)-> list[str]:
+
+def get_all_string_replacement_combinations(
+    string: str, old: str, new: str
+) -> list[str]:
     """
     Description:
         Get all replacement combinations for a string. This is used to validate user IDs.
@@ -522,6 +525,6 @@ def get_all_string_replacement_combinations(string: str, old: str, new: str)-> l
         for replace, pos in zip(combo, positions):
             if replace:
                 s_list[pos] = new
-        results.append(''.join(s_list))
+        results.append("".join(s_list))
 
     return results

--- a/wetlab/utils/common.py
+++ b/wetlab/utils/common.py
@@ -515,13 +515,13 @@ def get_all_string_replacement_combinations(string: str, old: str, new: str)-> l
         list of strings containing all possible combinations for the replacement
     """
     positions = [i for i, ch in enumerate(string) if ch == old]
-    results = []
+    results = [string]
 
     for combo in product([False, True], repeat=len(positions)):
         s_list = list(string)
         for replace, pos in zip(combo, positions):
             if replace:
-                s_list[pos] = '.'
+                s_list[pos] = new
         results.append(''.join(s_list))
 
     return results

--- a/wetlab/utils/common.py
+++ b/wetlab/utils/common.py
@@ -5,6 +5,7 @@ import re
 import socket
 import traceback
 from datetime import datetime, timezone
+from itertools import product
 from logging.config import fileConfig
 
 from django.contrib.auth.models import User
@@ -501,3 +502,26 @@ def open_log(config_file):
     fileConfig(config_file, disable_existing_loggers=False)
     logger = logging.getLogger()
     return logger
+
+def get_all_string_replacement_combinations(string: str, old: str, new: str)-> list[str]:
+    """
+    Description:
+        Get all replacement combinations for a string. This is used to validate user IDs.
+    Input:
+        string      # string to return replacements
+        old         # Substring to be replaced
+        new         # Substring to replace old by
+    Return:
+        list of strings containing all possible combinations for the replacement
+    """
+    positions = [i for i, ch in enumerate(string) if ch == old]
+    results = []
+
+    for combo in product([False, True], repeat=len(positions)):
+        s_list = list(string)
+        for replace, pos in zip(combo, positions):
+            if replace:
+                s_list[pos] = '.'
+        results.append(''.join(s_list))
+
+    return results

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -2185,7 +2185,7 @@ def _get_existing_stats_folder(conn, run_folder, experiment_name=""):
     logger = logging.getLogger(__name__)
     shared_folder = get_samba_shared_folder()
     base_folder = get_samba_application_shared_folder()
-    
+
     stats_file_paths = getattr(
         wetlab.config, "STATS_FILE_PATHS", [wetlab.config.STATS_FILE_PATH]
     )

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -2185,6 +2185,7 @@ def _get_existing_stats_folder(conn, run_folder, experiment_name=""):
     logger = logging.getLogger(__name__)
     shared_folder = get_samba_shared_folder()
     base_folder = get_samba_application_shared_folder()
+    
     stats_file_paths = getattr(
         wetlab.config, "STATS_FILE_PATHS", [wetlab.config.STATS_FILE_PATH]
     )

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -162,15 +162,19 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         )
         return users
 
-    # FIXME: Due to samplesheet limitations, we need to check all possible combinations of "dash to dot" 
+    # FIXME: Due to samplesheet limitations, we need to check all possible combinations of "dash to dot"
     # FIXME: When we develop a final solution, change below and "wetlab.common.get_all_string_replacement_combinations"
     userid_names = []
     invalid_names = []
 
     for user in users_in_sample_sheet:
-        all_user_replacement_combinations = wetlab.utils.common.get_all_string_replacement_combinations(user, old="-", new=".")
+        all_user_replacement_combinations = (
+            wetlab.utils.common.get_all_string_replacement_combinations(
+                user, old="-", new="."
+            )
+        )
         for user_permutation in all_user_replacement_combinations:
-             if user_permutation in user_id_list:
+            if user_permutation in user_id_list:
                 userid_names.append(user_permutation)
                 break
         else:
@@ -359,7 +363,6 @@ def get_user_ids_from_samplesheet(
 
     user_id_list_db = wetlab.utils.common.get_userid_list()
 
-
     user_ids = []
     if iskylims_user_column:
         user_ids = get_column_from_tabular_data(data, iskylims_user_column)
@@ -376,12 +379,16 @@ def get_user_ids_from_samplesheet(
     userid_names = []
 
     for user in user_ids:
-        all_user_replacement_combinations = wetlab.utils.common.get_all_string_replacement_combinations(user, old="-", new=".")
+        all_user_replacement_combinations = (
+            wetlab.utils.common.get_all_string_replacement_combinations(
+                user, old="-", new="."
+            )
+        )
         for user_permutation in all_user_replacement_combinations:
-             if user_permutation in user_id_list_db:
+            if user_permutation in user_id_list_db:
                 userid_names.append(user_permutation)
                 break
-    
+
     return userid_names
 
 

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -162,23 +162,8 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         )
         return users
 
-    # FIXME: Due to samplesheet limitations, we need to check all possible combinations of "dash to dot"
-    # FIXME: When we develop a final solution, change below and "wetlab.common.get_all_string_replacement_combinations"
-    userid_names = []
-    invalid_names = []
-
-    for user in users_in_sample_sheet:
-        all_user_replacement_combinations = (
-            wetlab.utils.common.get_all_string_replacement_combinations(
-                user, old="-", new="."
-            )
-        )
-        for user_permutation in all_user_replacement_combinations:
-            if user_permutation in user_id_list:
-                userid_names.append(user_permutation)
-                break
-        else:
-            invalid_names.append(user)
+    userid_names = [user for user in users_in_sample_sheet if user in user_id_list]
+    invalid_names = [user for user in users_in_sample_sheet if user not in user_id_list]
 
     if len(invalid_names) > 0:
         invalid_names = list(set(invalid_names))
@@ -375,7 +360,8 @@ def get_user_ids_from_samplesheet(
     if not user_ids and version == "2":
         user_ids = get_user_ids_from_project_name(samplesheet)
 
-    # FIXME: DUPLICATING VALIDATION LOGIC.
+    # FIXME: Due to samplesheet limitations, we need to check all possible combinations of "dash to dot"
+    # FIXME: When we develop a final solution, change below.
     userid_names = []
 
     for user in user_ids:

--- a/wetlab/utils/samplesheet.py
+++ b/wetlab/utils/samplesheet.py
@@ -10,6 +10,7 @@ from django.core.files.storage import FileSystemStorage
 
 # Local imports
 import wetlab.config
+import wetlab.utils.common
 
 # import wetlab.models
 
@@ -161,8 +162,19 @@ def validate_userid_in_user_iem_file(file_read, user_id_list):
         )
         return users
 
-    userid_names = [user for user in users_in_sample_sheet if user in user_id_list]
-    invalid_names = [user for user in users_in_sample_sheet if user not in user_id_list]
+    # FIXME: Due to samplesheet limitations, we need to check all possible combinations of "dash to dot" 
+    # FIXME: When we develop a final solution, change below and "wetlab.common.get_all_string_replacement_combinations"
+    userid_names = []
+    invalid_names = []
+
+    for user in users_in_sample_sheet:
+        all_user_replacement_combinations = wetlab.utils.common.get_all_string_replacement_combinations(user, old="-", new=".")
+        for user_permutation in all_user_replacement_combinations:
+             if user_permutation in user_id_list:
+                userid_names.append(user_permutation)
+                break
+        else:
+            invalid_names.append(user)
 
     if len(invalid_names) > 0:
         invalid_names = list(set(invalid_names))
@@ -345,6 +357,9 @@ def get_user_ids_from_samplesheet(
     version = samplesheet_version(samplesheet)
     iskylims_user_column = wetlab.config.TABULAR_DATA_ISKYLIMS_USER_COLUMN.get(version)
 
+    user_id_list_db = wetlab.utils.common.get_userid_list()
+
+
     user_ids = []
     if iskylims_user_column:
         user_ids = get_column_from_tabular_data(data, iskylims_user_column)
@@ -357,7 +372,17 @@ def get_user_ids_from_samplesheet(
     if not user_ids and version == "2":
         user_ids = get_user_ids_from_project_name(samplesheet)
 
-    return user_ids
+    # FIXME: DUPLICATING VALIDATION LOGIC.
+    userid_names = []
+
+    for user in user_ids:
+        all_user_replacement_combinations = wetlab.utils.common.get_all_string_replacement_combinations(user, old="-", new=".")
+        for user_permutation in all_user_replacement_combinations:
+             if user_permutation in user_id_list_db:
+                userid_names.append(user_permutation)
+                break
+    
+    return userid_names
 
 
 def get_projects_in_sample_sheet(samplesheet) -> list:


### PR DESCRIPTION
## Changes
- Modified samplesheet.py to add logic to check all possible combinations of a username with dashes instead of dots (e.g. "as-it.wa-s" would be checked for `as.it.wa-s`, `as-it.wa.s`, `as.it.wa.s`). When checking, original will always be preferred (Will be checked earlier)

## Possible future issues
- If there are multiple "unique" names with combination of dashes and dots (e.g. users "a.sv" and "a-sv"), this will cause issues.
- Project IDs are kept with dashes (e.g. MiSeq_i100_GEN_003_20260319_enrique-sapena)
- Stored samplesheets also keep dashes in the project IDs