### PR TITLE
Add bulk sample project values API endpoint

### DIFF
--- a/wetlab/api/urls.py
+++ b/wetlab/api/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
         views.fetch_sample_information,
         name="fetch_sample_information",
     ),
+    path(
+        "sample-project-values-bulk",
+        views.fetch_sample_project_values_bulk,
+        name="fetch_sample_project_values_bulk",
+    ),
     path("create-sample", views.create_sample_data, name="create_sample_data"),
     path("sample-fields", views.sample_fields, name="sample_fields"),
     path("projects-fields", views.sample_project_fields, name="sample_project_fields"),

--- a/wetlab/api/views.py
+++ b/wetlab/api/views.py
@@ -1,4 +1,5 @@
 from django.http import QueryDict
+from django.db.models import Q
 from django.db.models.functions import Lower
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -103,6 +104,13 @@ sample_project_name = openapi.Parameter(
     "sample_project_name",
     openapi.IN_QUERY,
     description="Select the project to get all samples assigned to it",
+    type=openapi.TYPE_STRING,
+)
+
+sample_project_value_fields = openapi.Parameter(
+    "fields",
+    openapi.IN_QUERY,
+    description="Comma-separated sample project field names or descriptions to fetch",
     type=openapi.TYPE_STRING,
 )
 
@@ -292,6 +300,75 @@ def create_sample_data(request):
             {"ERROR": f"Request method must be POST, received {request.method}"},
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+
+@swagger_auto_schema(
+    method="get",
+    operation_description="Get selected project values for multiple samples",
+    manual_parameters=[sample_list, sample_project_value_fields],
+)
+@api_view(["GET"])
+def fetch_sample_project_values_bulk(request):
+    """Return selected project values for a comma-separated list of samples."""
+    samples_param = request.GET.get("samples", "").strip()
+    if not samples_param:
+        return Response(
+            {"ERROR": "Missing 'samples' parameter"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    sample_names = [
+        sample.strip() for sample in samples_param.split(",") if sample.strip()
+    ]
+    if not sample_names:
+        return Response(
+            {"ERROR": "Missing 'samples' parameter"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    fields_param = request.GET.get("fields", "").strip()
+    requested_fields = [
+        field.strip() for field in fields_param.split(",") if field.strip()
+    ]
+
+    sample_objs = core.models.Samples.objects.filter(sample_name__in=sample_names)
+    sample_data = {
+        sample_obj.sample_name: {
+            "sample_project": (
+                sample_obj.sample_project.get_sample_project_name()
+                if sample_obj.sample_project
+                else ""
+            ),
+            "Project values": {},
+        }
+        for sample_obj in sample_objs.select_related("sample_project")
+    }
+
+    project_value_objs = core.models.SampleProjectsFieldsValue.objects.filter(
+        sample_id__sample_name__in=sample_names
+    ).select_related("sample_id", "sample_project_field_id")
+    if requested_fields:
+        project_value_objs = project_value_objs.filter(
+            Q(sample_project_field_id__sample_project_field_name__in=requested_fields)
+            | Q(
+                sample_project_field_id__sample_project_field_description__in=(
+                    requested_fields
+                )
+            )
+        )
+
+    for project_value_obj in project_value_objs:
+        sample_name = project_value_obj.sample_id.sample_name
+        field_obj = project_value_obj.sample_project_field_id
+        field_name = field_obj.sample_project_field_name
+        display_name = field_obj.sample_project_field_description or field_name
+        sample_data.setdefault(
+            sample_name, {"sample_project": "", "Project values": {}}
+        )["Project values"][display_name] = (
+            project_value_obj.sample_project_field_value or ""
+        )
+
+    return Response({"data": sample_data}, status=status.HTTP_200_OK)
 
 
 @swagger_auto_schema(

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -875,7 +875,11 @@ def _render_supercronic_file():
 
 
 def _start_supercronic():
-    if _is_supercronic_disabled() or _is_supercronic_active() or shutil.which("supercronic") is None:
+    if (
+        _is_supercronic_disabled()
+        or _is_supercronic_active()
+        or shutil.which("supercronic") is None
+    ):
         return
 
     _render_supercronic_file()

--- a/wetlab/utils/crontab_process.py
+++ b/wetlab/utils/crontab_process.py
@@ -1457,10 +1457,9 @@ def store_sample_sheet_if_not_defined_in_run(
                                 a unique file name
         now     # Present time of the server
         run_updated # RunProcess object for miseq run
-        sample_sheet_on_database # sample sheet path used in database
         timestr     # Present time including 3 digits for miliseconds
     Return:
-        sample_sheet_on_database
+        saved_sample_sheet
     """
     logger = logging.getLogger(__name__)
     logger.debug(
@@ -1477,10 +1476,6 @@ def store_sample_sheet_if_not_defined_in_run(
         new_sample_sheet_name,
     )
     logger.info("%s : new sample sheet name %s", experiment_name, new_sample_sheet_file)
-    # Path to be included in database
-    sample_sheet_on_database = os.path.join(
-        wetlab.config.RUN_SAMPLE_SHEET_DIRECTORY, new_sample_sheet_name
-    )
     # Move sample sheet to final folder
     os.rename(l_sample_sheet_path, new_sample_sheet_file)
     # Update the run with the sample sheet information  (full_path, relative_path, file_name)


### PR DESCRIPTION
This PR adds a new API endpoint `sample-project-values-bulk` that allows clients to fetch selected project field values for multiple samples in a single request. This is useful when you need to retrieve project-specific metadata (like protocol, index, etc.) for multiple samples at once.

#### Changes

- **New API endpoint**: `GET /api/samples/sample-project-values-bulk`
  - Accepts a comma-separated list of sample names via `samples` parameter
  - Accepts optional comma-separated field filter via `fields` parameter
  - Fields can be matched by name or description for flexibility
  
- **New view function**: `fetch_sample_project_values_bulk()` in `wetlab/api/views.py`
  - Returns project field values organized by sample
  - Supports filtering by field name OR field description
  - Optimized with `select_related()` to minimize database queries
  
- **New OpenAPI parameter**: `sample_project_value_fields` for proper API documentation

#### Use Case

This was made to reduce request from RELECOV to take long times